### PR TITLE
Translate functions so that they have impl Into parameters. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "naga-rust-back"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.0",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "naga-rust-embed"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "exhaust",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ repository = "https://github.com/kpreid/naga-rust/"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-naga-rust-back = { version = "0.1.0", path = "back" }
+naga-rust-back = { version = "0.2.0", path = "back" }
 naga-rust-embed = { version = "0.1.0", path = "embed" }
 naga-rust-macros = { version = "0.1.0", path = "macros" }
 naga-rust-rt = { version = "0.1.0", path = "rt" }

--- a/back/CHANGELOG.md
+++ b/back/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.2.0 (Unreleased)
 
+* The signatures of generated functions have been changed; whenever the shader code has a parameter `x: T` where `T` is some scalar or vector type, the generated code now uses `x: impl Into<T>`. (This allows passing arrays as arguments where vectors are wanted.)
+
 ## 0.1.0 (2025-03-25)
 
 Initial public release.

--- a/back/CHANGELOG.md
+++ b/back/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog for `naga-rust-back`
 
+## 0.2.0 (Unreleased)
+
 ## 0.1.0 (2025-03-25)
 
 Initial public release.

--- a/back/Cargo.toml
+++ b/back/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "naga-rust-back"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.85.0"
 description = "Backend for the Naga shader translator which generates Rust code."

--- a/back/tests/textual.rs
+++ b/back/tests/textual.rs
@@ -71,8 +71,11 @@ fn visibility_control() {
         translate(Config::new(), "fn foo() {}"),
         indoc::indoc! {
             r"
-            #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
             fn foo() {
+                v_foo()
+            }
+            #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
+            fn v_foo() {
                 return;
             }
             
@@ -83,8 +86,11 @@ fn visibility_control() {
         translate(Config::new().public_items(true), "fn foo() {}"),
         indoc::indoc! {
             r"
-            #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
             pub fn foo() {
+                v_foo()
+            }
+            #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
+            fn v_foo() {
                 return;
             }
             
@@ -107,8 +113,11 @@ fn entry_point() {
         indoc::indoc! {
             r"
             #[::naga_rust_rt::fragment]
+            fn main(position: impl ::naga_rust_rt::Into<::naga_rust_rt::Vec4<f32>>) -> ::naga_rust_rt::Vec4<f32> {
+                v_main(position.into())
+            }
             #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
-            fn main(position: ::naga_rust_rt::Vec4<f32>) -> ::naga_rust_rt::Vec4<f32> {
+            fn v_main(position: ::naga_rust_rt::Vec4<f32>) -> ::naga_rust_rt::Vec4<f32> {
                 return ::naga_rust_rt::Vec4::splat(1f32);
             }
             "
@@ -164,8 +173,11 @@ fn switch() {
         ),
         indoc::indoc! {
             "
+            fn switching(x: impl ::naga_rust_rt::Into<i32>) -> i32 {
+                v_switching(x.into())
+            }
             #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
-            fn switching(x: i32) -> i32 {
+            fn v_switching(x: i32) -> i32 {
                 match x {
                     0i32 => {
                         return 0i32;
@@ -233,8 +245,11 @@ fn array_length() {
                 }}
             }
             impl Globals {
-            #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
             fn length(&self, ) -> u32 {
+                self.v_length()
+            }
+            #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
+            fn v_length(&self, ) -> u32 {
                 return (&self.arr).len();
             }
 
@@ -286,8 +301,11 @@ fn precedence_of_prefix_and_postfix() {
         ),
         indoc::indoc! {
             "
-            #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
             fn f(p: &mut [i32; 4]) -> i32 {
+                v_f(p)
+            }
+            #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
+            fn v_f(p: &mut [i32; 4]) -> i32 {
                 let _e2 = (*p)[2 as usize];
                 return (!_e2);
             }

--- a/embed/Cargo.toml
+++ b/embed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "naga-rust-embed"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.85.0"
 description = "Translates WGSL shader code to Rust embedded in your Rust code."

--- a/embed/tests/interop/operators.rs
+++ b/embed/tests/interop/operators.rs
@@ -80,7 +80,7 @@ pub(crate) fn bool_vector_ops() {
     );
 
     for [a, b, c] in <[[bool; 4]; 3]>::exhaust() {
-        for (i, element) in <[bool; 4]>::from(bool_vector_func(a.into(), b.into(), c.into()))
+        for (i, element) in <[bool; 4]>::from(bool_vector_func(a, b, c))
             .into_iter()
             .enumerate()
         {

--- a/rt/src/vector.rs
+++ b/rt/src/vector.rs
@@ -8,6 +8,9 @@ use num_traits::ConstZero;
 #[cfg_attr(test, allow(unused_imports))]
 use num_traits::float::Float as _;
 
+// Used for argument conversion shim functions
+pub use core::convert::Into;
+
 // -------------------------------------------------------------------------------------------------
 // Vector type declarations.
 //


### PR DESCRIPTION
This will clear the way for using `rt::Scalar` for scalars (for #4) without making the functions inconvenient to use by requiring explicit conversion of everything.

I’m not yet sure whether `Into` is the right choice — it might be better to produce strictly non-generic code — but it is flexible while things are still changing.

Future work:
* Actually use `rt::Scalar` as planned.
* `use_into_for_arg()` should become part of some broader system of consistent type translation.
* Consider whether we really want `impl Into` or whether the shim functions should have merely different concrete types. (This question should be revisited once SIMD #3 is working.)
