### PR TITLE
Preparation for scalar math revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,6 +777,7 @@ version = "0.1.0"
 dependencies = [
  "naga-rust-macros",
  "num-traits",
+ "paste",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ indoc = { version = "2.0.1", default-features = false }
 naga = { version = "25.0.1", default-features = false }
 num-traits = { version = "0.2.19", default-features = false }
 once_cell = { version = "1.21.3", default-features = false }
+paste = {version = "1.0.15", default-features = false }
 pretty_assertions = { version = "1.2.0" }
 
 [workspace.lints.rust]

--- a/back/src/writer.rs
+++ b/back/src/writer.rs
@@ -1144,6 +1144,13 @@ impl Writer {
                         self.write_expr(out, right, expr_ctx)?;
                         write!(out, ")")?;
                     }
+                    (_, BinOpClassified::ShortCircuit(bop)) => {
+                        write!(out, "(")?;
+                        self.write_expr(out, left, expr_ctx)?;
+                        write!(out, " {} ", bop.to_binary_operator())?;
+                        self.write_expr(out, right, expr_ctx)?;
+                        write!(out, ")")?;
+                    }
                 }
             }
             Expression::Access { base, index } => {

--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -28,6 +28,7 @@ std = []
 [dependencies]
 num-traits = { workspace = true, default-features = false, features = ["libm"] }
 naga-rust-macros.workspace = true
+paste.workspace = true
 
 [lints.clippy]
 std_instead_of_alloc = "warn"

--- a/rt/src/vector.rs
+++ b/rt/src/vector.rs
@@ -471,6 +471,14 @@ macro_rules! impl_vector_regular_fns {
                     )*
                 }
             }
+
+            paste::paste! {
+                $(
+                    pub fn [< set_ $component >](&mut self, value: T) {
+                        self.$component = value;
+                    }
+                )*
+            }
         }
 
         impl_vector_integer_arithmetic!($ty, i32, $($component)*);


### PR DESCRIPTION
Part of #4.

* Use setter functions for vector components in `write_store_statement()`; that is, generate `some_vector.set_x(0)` insteadd of `some_vector.x = 0`. This will be necessary both for `Scalar` and likely for SIMD.
* Handle short-circuiting (i.e. control flow affecting) binary operators separately from non-short-circuiting binary operators (even though there are no effects of this yet).