### PR TITLE
Switch over to using `rt::Scalar` for scalars.

### DIFF
--- a/back/tests/textual.rs
+++ b/back/tests/textual.rs
@@ -72,7 +72,7 @@ fn visibility_control() {
         indoc::indoc! {
             r"
             fn foo() {
-                v_foo()
+                v_foo().into()
             }
             #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
             fn v_foo() {
@@ -87,7 +87,7 @@ fn visibility_control() {
         indoc::indoc! {
             r"
             pub fn foo() {
-                v_foo()
+                v_foo().into()
             }
             #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
             fn v_foo() {
@@ -114,11 +114,11 @@ fn entry_point() {
             r"
             #[::naga_rust_rt::fragment]
             fn main(position: impl ::naga_rust_rt::Into<::naga_rust_rt::Vec4<f32>>) -> ::naga_rust_rt::Vec4<f32> {
-                v_main(position.into())
+                v_main(position.into()).into()
             }
             #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
             fn v_main(position: ::naga_rust_rt::Vec4<f32>) -> ::naga_rust_rt::Vec4<f32> {
-                return ::naga_rust_rt::Vec4::splat(1f32);
+                return ::naga_rust_rt::Vec4::splat_from_scalar(::naga_rust_rt::Scalar(1f32));
             }
             "
         }
@@ -135,11 +135,11 @@ fn global_variable_enabled() {
         indoc::indoc! {
             "
             struct Globals {
-                foo: i32,
+                foo: ::naga_rust_rt::Scalar<i32>,
             }
             impl Default for Globals {
                 fn default() -> Self { Self {
-                    foo: 1i32,
+                    foo: ::naga_rust_rt::Scalar(1i32),
                 }}
             }
             impl Globals {
@@ -173,20 +173,20 @@ fn switch() {
         ),
         indoc::indoc! {
             "
-            fn switching(x: impl ::naga_rust_rt::Into<i32>) -> i32 {
-                v_switching(x.into())
+            fn switching(x: impl ::naga_rust_rt::Into<::naga_rust_rt::Scalar<i32>>) -> i32 {
+                v_switching(x.into()).into()
             }
             #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
-            fn v_switching(x: i32) -> i32 {
-                match x {
+            fn v_switching(x: ::naga_rust_rt::Scalar<i32>) -> ::naga_rust_rt::Scalar<i32> {
+                match ::naga_rust_rt::Scalar::into_inner(x) {
                     0i32 => {
-                        return 0i32;
+                        return ::naga_rust_rt::Scalar(0i32);
                     }
                     1i32 | 2i32 => {
-                        return 1i32;
+                        return ::naga_rust_rt::Scalar(1i32);
                     }
                     _ => {
-                        return 2i32;
+                        return ::naga_rust_rt::Scalar(2i32);
                     }
                 }
             }
@@ -233,11 +233,12 @@ fn array_length() {
         // TODO: we don't yet fully support bindings properly so lots of this code is nonsense.
         // This test is only intending to check the translation of arrayLength(), which is
         // hard to test separately since it must take a `ptr<storage, array<..>>`.
+        //
         indoc::indoc! {
             "
             struct Globals {
                 // group(0) binding(1)
-                arr: [u32],
+                arr: [::naga_rust_rt::Scalar<u32>],
             }
             impl Default for Globals {
                 fn default() -> Self { Self {
@@ -246,10 +247,10 @@ fn array_length() {
             }
             impl Globals {
             fn length(&self, ) -> u32 {
-                self.v_length()
+                self.v_length().into()
             }
             #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
-            fn v_length(&self, ) -> u32 {
+            fn v_length(&self, ) -> ::naga_rust_rt::Scalar<u32> {
                 return (&self.arr).len();
             }
 
@@ -301,11 +302,11 @@ fn precedence_of_prefix_and_postfix() {
         ),
         indoc::indoc! {
             "
-            fn f(p: &mut [i32; 4]) -> i32 {
-                v_f(p)
+            fn f(p: &mut [::naga_rust_rt::Scalar<i32>; 4]) -> i32 {
+                v_f(p).into()
             }
             #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
-            fn v_f(p: &mut [i32; 4]) -> i32 {
+            fn v_f(p: &mut [::naga_rust_rt::Scalar<i32>; 4]) -> ::naga_rust_rt::Scalar<i32> {
                 let _e2 = (*p)[2 as usize];
                 return (!_e2);
             }

--- a/embed/src/lib.rs
+++ b/embed/src/lib.rs
@@ -83,7 +83,7 @@ pub use naga_rust_macros::include_wgsl_mr;
 ///     "var<private> foo: i32 = 10;",
 /// );
 ///
-/// assert_eq!(Globals::default().foo, 10);
+/// assert_eq!(Globals::default().foo, naga_rust_embed::rt::Scalar(10));
 /// ```
 ///
 #[doc = include_str!("configuration_syntax.md")]

--- a/embed/tests/interop/arrays.rs
+++ b/embed/tests/interop/arrays.rs
@@ -1,4 +1,5 @@
 use naga_rust_embed::wgsl;
+use naga_rust_rt::Scalar;
 
 #[test]
 pub(crate) fn array_ctor() {
@@ -22,7 +23,9 @@ pub(crate) fn array_access_fixed() {
         "
     );
 
-    let mut a = [10, 100];
+    // TODO: The type expected ought to be [u32; 2] instead, but it will require further work
+    // to make that actually true.
+    let mut a = [Scalar(10), Scalar(100)];
     modify_array(&mut a);
-    assert_eq!(a, [11, 102]);
+    assert_eq!(a, [Scalar(11), Scalar(102)]);
 }

--- a/embed/tests/interop/constants.rs
+++ b/embed/tests/interop/constants.rs
@@ -1,18 +1,28 @@
+use naga_rust_embed::rt::Scalar;
 use naga_rust_embed::wgsl;
 
 #[test]
 fn global_constant() {
-    wgsl!("const X: f32 = 1234.0;");
-    assert_eq!(X, 1234.0);
+    wgsl!(
+        r"
+        const X: f32 = 1234.0;
+        fn get_x() -> f32 {
+            return X;
+        }
+        "
+    );
+    // TODO: Exposing Scalar here is largely accidental. Should we really?
+    assert_eq!(X, Scalar(1234.0));
+    assert_eq!(get_x(), 1234.0);
 }
 
 #[test]
 fn local_constant() {
     wgsl!(
-        r"fn foo() -> f32 {
+        r"fn get_x() -> f32 {
             const X: f32 = 1234.0;
             return X;
         }"
     );
-    assert_eq!(foo(), 1234.0);
+    assert_eq!(get_x(), 1234.0);
 }

--- a/embed/tests/interop/operators.rs
+++ b/embed/tests/interop/operators.rs
@@ -1,7 +1,7 @@
 use exhaust::Exhaust as _;
 
+use naga_rust_embed::rt::{Scalar, Vec2, Vec4};
 use naga_rust_embed::wgsl;
-use naga_rust_rt::{Vec2, Vec4};
 
 #[test]
 pub(crate) fn scalar_arithmetic() {
@@ -33,9 +33,9 @@ pub(crate) fn scalar_pointer() {
         }"
     );
 
-    let mut x = 10;
+    let mut x = Scalar(10);
     add_one_ptr(&mut x);
-    assert_eq!(x, 11);
+    assert_eq!(x, Scalar(11));
 }
 
 #[test]

--- a/examples/render/src/main.rs
+++ b/examples/render/src/main.rs
@@ -49,14 +49,20 @@ fn run_fragment_shader(time: f32, buffer: &mut [u32], size: PhysicalSize<u32>) {
         .enumerate()
         .for_each(|(y, row)| {
             for (x, pixel) in row.iter_mut().enumerate() {
-                // TODO: `rt` is not supposed to be in scope here
                 #[allow(clippy::cast_precision_loss)]
                 let fragment_position = rt::Vec4::new(x as f32, y as f32, 0.0, 0.0);
 
-                let result = Shader { time }.main(fragment_position);
+                // TODO: There should be a nice constructor API for uniforms.
+                // Maybe a separate struct.
+                let result = Shader {
+                    time: rt::Scalar(time),
+                }
+                .main(fragment_position);
 
                 // In a real application this should be sRGB encoding.
-                let v = (result * 255.0).cast_elem_as_u32().map(|c| c.clamp(0, 255));
+                let v = (result * rt::Scalar(255.0))
+                    .cast_elem_as_u32()
+                    .map(|c| c.clamp(0, 255));
 
                 *pixel = v.z | (v.y << 8) | (v.x << 16);
             }


### PR DESCRIPTION
Fixes #4. (There may still be arithmetic implementation bugs, but they are individual bugs instead of an overall design flaw.)

This causes arithmetic to be executed with Naga/shader semantics instead of Rust language and standard library semantics (insofar as we implement shader arithmetic correctly), and it will aid in adding explicit vectorization support (because `Scalar` will be able to contain a vector of subgroup/quad data).

The points at which translation between `Scalar<T>` and `T` occur are not well-founded, and this change probably breaks some shader code that previously worked; however, the tests pass and I believe it will be easier to work forward from this than to seek immediate perfection.