### PR TITLE
Add `resource_struct` option and separate resources from globals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Development status
 These libraries are in an early stage of development and many features do not work yet.
 Expect compilation failures, incorrect behaviors, and to have to tweak your code to fit,
 if you wish to use them.
-Broadly, simple mathematical functions will work, and bindings, textures, atomics,
+Broadly, simple mathematical functions will work, and matrices, textures, atomics,
 derivatives, and workgroup operations will not.
 
 

--- a/back/src/config.rs
+++ b/back/src/config.rs
@@ -1,6 +1,8 @@
 use alloc::borrow::Cow;
 use alloc::string::String;
 
+use crate::util::GlobalKind;
+
 /// Configuration/builder for options for Rust code generation.
 ///
 /// This configuration allows you to control syntactic characteristics of the output,
@@ -10,6 +12,7 @@ pub struct Config {
     pub(crate) flags: WriterFlags,
     pub(crate) runtime_path: Cow<'static, str>,
     pub(crate) global_struct: Option<String>,
+    pub(crate) resource_struct: Option<String>,
     #[allow(dead_code, reason = "reminding ourselves of the future")]
     pub(crate) edition: Edition,
 }
@@ -28,6 +31,7 @@ impl Config {
             flags: WriterFlags::empty(),
             runtime_path: Cow::Borrowed("::naga_rust_rt"),
             global_struct: None,
+            resource_struct: None,
             edition: Edition::Rust2024,
         }
     }
@@ -57,6 +61,8 @@ impl Config {
 
     /// Sets whether generated items have `pub` visibility instead of private.
     ///
+    /// This option applies to all functions or methods, and all fields of generated structs.
+    ///
     /// The default is `false`.
     #[must_use]
     pub fn public_items(mut self, value: bool) -> Self {
@@ -84,14 +90,63 @@ impl Config {
 
     /// Allow declarations of global variables, generate a struct with the given `name` to hold
     /// them, and make all functions methods of that struct.
+    ///
+    /// The struct has one constructor method, which is declared as either
+    /// `const fn new()` or `const fn new(resources: &ResourceStructName)`
+    /// depending on whether [`resource_struct()`][Self::resource_struct] is also set.
+    /// If there are no parameters, then it also implements [`Default`].
+    ///
+    /// If this option is not set, shaders may not contain declarations of variables with
+    /// [address spaces] `private` or `workgroup`.
+    ///
+    /// [address spaces]: https://www.w3.org/TR/WGSL/#address-space
     #[must_use]
     pub fn global_struct(mut self, name: impl Into<String>) -> Self {
         self.global_struct = Some(name.into());
         self
     }
 
-    pub(crate) fn use_global_struct(&self) -> bool {
-        self.global_struct.is_some()
+    /// Allow declarations of resources (e.g. uniforms), generate a struct with the given `name` to
+    /// hold them, and, if [`global_struct()`][Self::global_struct] is not also set,
+    /// make all functions methods of that struct.
+    ///
+    /// If this option is not set, shaders may not contain declarations of variables with
+    /// [address spaces] `uniform` or `storage`.
+    ///
+    /// [address spaces]: https://www.w3.org/TR/WGSL/#address-space
+    #[must_use]
+    pub fn resource_struct(mut self, name: impl Into<String>) -> Self {
+        self.resource_struct = Some(name.into());
+        self
+    }
+}
+
+/// Internal methods that help generate code based on this config.
+impl Config {
+    /// Returns whether we should generate functions instead of free functions.
+    pub(crate) fn functions_are_methods(&self) -> bool {
+        self.global_struct.is_some() || self.resource_struct.is_some()
+    }
+
+    /// Returns what the self type of our `impl` block is, if we have one.
+    pub(crate) fn impl_type(&self) -> Option<&str> {
+        match self.global_struct {
+            Some(ref name) => Some(name),
+            None => self.resource_struct.as_deref(),
+        }
+    }
+
+    pub(crate) fn global_field_access_prefix(
+        &self,
+        variable: &naga::GlobalVariable,
+    ) -> &'static str {
+        match (GlobalKind::of_variable(variable), &self.global_struct) {
+            // If we have both resource struct and global struct, the resource struct is
+            // nested inside the global struct.
+            (Some(GlobalKind::Resource), Some(_)) => "self.resources.",
+            (Some(GlobalKind::Resource), None) | (Some(GlobalKind::Variable), _) => "self.",
+            _ => unreachable!(),
+        }
     }
 }
 
@@ -108,7 +163,7 @@ bitflags::bitflags! {
         const RAW_POINTERS = 0x2;
 
         /// Generate items with `pub` visibility instead of private.
-        const PUBLIC = 0x3;
+        const PUBLIC = 0x4;
     }
 }
 

--- a/back/src/conv.rs
+++ b/back/src/conv.rs
@@ -39,6 +39,7 @@ pub(crate) fn unwrap_to_rust<T: TryToRust + Copy + fmt::Debug>(value: T) -> &'st
 }
 
 // Contains all keywords, strict or weak, in 2024 and any previous edition, sorted.
+// Also contains names we want to reserve for our own purposes.
 // https://doc.rust-lang.org/reference/keywords.html
 const KEYWORDS_2024_SLICE: &[&str] = &[
     "abstract",
@@ -77,6 +78,7 @@ const KEYWORDS_2024_SLICE: &[&str] = &[
     "pub",
     "raw",
     "ref",
+    "resources", // not a Rust keyword; reserved for ourselves.
     "return",
     "safe",
     "self",

--- a/back/src/lib.rs
+++ b/back/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! This library is in an early stage of development and many features do not work yet;
 //! this may be indicated by returned errors or by the generated code failing to compile.
-//! Broadly, simple mathematical functions will work, and bindings, textures, atomics,
+//! Broadly, simple mathematical functions will work, and matrices, textures, atomics,
 //! derivatives, and workgroup operations will not.
 //!
 //! [`naga_rust_rt`]: https://docs.rs/naga-rust-rt
@@ -66,10 +66,17 @@ pub enum Error {
         found: &'static str,
     },
 
-    /// To use a shader with global variables, [`Config::global_struct()`] must be set.
+    /// To use a shader with private global variables, [`Config::global_struct()`] must be set.
     #[non_exhaustive]
     GlobalVariablesNotEnabled {
         /// The name of one of the prohibited global variables.
+        example: String,
+    },
+
+    /// To use a shader with resources, [`Config::resource_struct()`] must be set.
+    #[non_exhaustive]
+    ResourcesNotEnabled {
+        /// The name of one of the prohibited resources.
         example: String,
     },
 }
@@ -91,7 +98,11 @@ impl fmt::Display for Error {
             }
             Error::GlobalVariablesNotEnabled { example } => write!(
                 f,
-                "global variable `{example}` found in shader, but not enabled in Config"
+                "global variable `{example}` found in shader, but `global_struct` is not configured"
+            ),
+            Error::ResourcesNotEnabled { example } => write!(
+                f,
+                "resource `{example}` found in shader, but `resource_struct` is not configured"
             ),
         }
     }

--- a/back/src/util.rs
+++ b/back/src/util.rs
@@ -14,3 +14,49 @@ impl LevelNext for naga::back::Level {
         Self(self.0.saturating_add(1))
     }
 }
+
+/// Classifies address spaces into two kinds: the kind that go in our global variables struct,
+/// and the kind that go in our resources struct.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GlobalKind {
+    Variable,
+    Resource,
+}
+
+impl GlobalKind {
+    /// Returns `None` if this address space can’t be a global.
+    pub fn new(address_space: naga::AddressSpace) -> Option<Self> {
+        match address_space {
+            // Function locals — should never appear as a global.
+            naga::AddressSpace::Function => None,
+
+            // Mutable global data
+            naga::AddressSpace::Private => Some(GlobalKind::Variable),
+            naga::AddressSpace::WorkGroup => Some(GlobalKind::Variable),
+
+            // Resources
+            naga::AddressSpace::Uniform => Some(GlobalKind::Resource),
+            naga::AddressSpace::Storage { access: _ } => Some(GlobalKind::Resource),
+            naga::AddressSpace::Handle => Some(GlobalKind::Resource),
+
+            // Unsupported
+            naga::AddressSpace::Immediate => None,
+            naga::AddressSpace::TaskPayload => None,
+            naga::AddressSpace::RayPayload => None,
+            naga::AddressSpace::IncomingRayPayload => None,
+        }
+    }
+
+    pub fn of_variable(variable: &naga::GlobalVariable) -> Option<Self> {
+        Self::new(variable.space)
+    }
+
+    pub fn filter(
+        self,
+        variables: &naga::Arena<naga::GlobalVariable>,
+    ) -> impl Iterator<Item = (naga::Handle<naga::GlobalVariable>, &naga::GlobalVariable)> {
+        variables
+            .iter()
+            .filter(move |(_, v)| Self::of_variable(v) == Some(self))
+    }
+}

--- a/back/src/writer.rs
+++ b/back/src/writer.rs
@@ -12,10 +12,10 @@ use naga::{
     valid::ModuleInfo,
 };
 
-use crate::config::WriterFlags;
 use crate::conv::{self, BinOpClassified, unwrap_to_rust};
 use crate::util::{Gensym, LevelNext};
 use crate::{Config, Error};
+use crate::{config::WriterFlags, util::GlobalKind};
 
 // -------------------------------------------------------------------------------------------------
 
@@ -211,10 +211,14 @@ impl Writer {
             &[FN_INTERNAL_TYPES_PREFIX],
             &mut self.names,
         );
+
+        // TODO: We actually want to say “treat this as reserved but do not rename it”,
+        // but Namer doesn’t have that option
         if let Some(g) = &config.global_struct {
-            // TODO: We actually want to say “treat this as reserved but do not rename it”,
-            // but Namer doesn’t have that option
             namer.call(g);
+        }
+        if let Some(r) = &config.resource_struct {
+            namer.call(r);
         }
         named_expressions.clear();
     }
@@ -264,34 +268,91 @@ impl Writer {
             }
         }
 
-        // If we are using global variables, write the `struct` that contains them.
-        if let Some(global_struct) = self.config.global_struct.clone() {
-            writeln!(out, "struct {global_struct} {{")?;
-            for (handle, global) in module.global_variables.iter() {
-                self.write_global_variable_as_struct_field(out, module, global, handle)?;
+        // If we are using resources, write the `struct` that contains them.
+        {
+            let mut resource_iter = GlobalKind::Resource.filter(&module.global_variables);
+            if let Some(ref resource_struct) = self.config.resource_struct {
+                writeln!(out, "struct {resource_struct} {{")?;
+                for (handle, global) in resource_iter {
+                    self.write_global_variable_as_struct_field(out, module, global, handle)?;
+                }
+                writeln!(out, "}}")?;
+            } else if let Some((_, example)) = resource_iter.next() {
+                return Err(Error::ResourcesNotEnabled {
+                    example: example.name.clone().unwrap_or_default(),
+                });
             }
-            // TODO: instead of trying to implement Default, make a constructor function
-            // for all globals that use bindings rather than initializers
-            writeln!(
-                out,
-                "}}\n\
-                impl Default for {global_struct} {{\n\
-                {INDENT}fn default() -> Self {{ Self {{"
-            )?;
-            for (handle, global) in module.global_variables.iter() {
-                self.write_global_variable_as_field_initializer(out, module, info, global, handle)?;
-            }
-            writeln!(out, "{INDENT}}}}}\n}}")?;
-
-            // Start the `impl` block of the functions
-            writeln!(out, "impl {global_struct} {{")?;
-        } else if let Some((_, example)) = module.global_variables.iter().next() {
-            return Err(Error::GlobalVariablesNotEnabled {
-                example: example.name.clone().unwrap_or_default(),
-            });
         }
 
-        // Write all regular functions (which may or may not be in the `impl` block from above).
+        // If we are using global variables, write the `struct` that contains them.
+        let global_lifetime_generics =
+            if self.config.global_struct.is_some() && self.config.resource_struct.is_some() {
+                "<'g>"
+            } else {
+                ""
+            };
+        {
+            let mut global_variable_iter = GlobalKind::Variable.filter(&module.global_variables);
+            if let Some(ref global_struct) = self.config.global_struct {
+                let visibility = self.visibility();
+                writeln!(out, "struct {global_struct}{global_lifetime_generics} {{")?;
+                if let Some(ref resource_struct_name) = self.config.resource_struct {
+                    writeln!(
+                        out,
+                        "{INDENT}{visibility}resources: &'g {resource_struct_name},"
+                    )?;
+                }
+                for (handle, global) in global_variable_iter {
+                    self.write_global_variable_as_struct_field(out, module, global, handle)?;
+                }
+                write!(
+                    out,
+                    "}}\n\
+                    impl{global_lifetime_generics} {global_struct}{global_lifetime_generics} {{\n\
+                    {INDENT}{visibility}const fn new(",
+                )?;
+                // Define new() function with parameter list depending on whether the resource
+                // struct is needed.
+                if let Some(ref resource_struct_name) = self.config.resource_struct {
+                    write!(out, "resources: &'g {resource_struct_name}")?;
+                }
+                writeln!(out, ") -> Self {{ Self {{")?;
+
+                if self.config.resource_struct.is_some() {
+                    // Note that we reserve the name “resources” using the keyword set.
+                    writeln!(out, "{INDENT}{INDENT}resources,")?;
+                }
+                for (handle, global) in GlobalKind::Variable.filter(&module.global_variables) {
+                    self.write_global_variable_as_field_initializer(
+                        out, module, info, global, handle,
+                    )?;
+                }
+                writeln!(out, "{INDENT}}}}}\n}}")?;
+
+                if self.config.resource_struct.is_none() {
+                    // If the global struct doesn’t need a resource struct,
+                    // then it can implement Default.
+                    writeln!(
+                        out,
+                        "impl Default for {global_struct} {{ fn default() -> Self {{ Self::new() }} }}"
+                    )?;
+                }
+            } else if let Some((_, example)) = global_variable_iter.next() {
+                return Err(Error::GlobalVariablesNotEnabled {
+                    example: example.name.clone().unwrap_or_default(),
+                });
+            }
+        }
+
+        // If we are making methods rather than free functions, start the `impl` block
+        if let Some(name) = self.config.impl_type() {
+            writeln!(
+                out,
+                "impl{global_lifetime_generics} {name}{global_lifetime_generics} {{"
+            )?;
+        }
+
+        // Write all regular functions (which may or may not be in an `impl` block from above).
         for (handle, function) in module.functions.iter() {
             let fun_info = &info[handle];
 
@@ -340,7 +401,7 @@ impl Writer {
             }
         }
 
-        if self.config.use_global_struct() {
+        if self.config.impl_type().is_some() {
             // End the `impl` block
             writeln!(out, "}}")?;
         }
@@ -400,7 +461,7 @@ impl Writer {
         };
         write!(out, "{visibility}fn {name_prefix}{func_name}(")?;
 
-        if self.config.use_global_struct() {
+        if self.config.functions_are_methods() {
             // TODO: need to figure out whether &mut is needed
             write!(out, "&self, ")?;
         } else if func_ctx.info.global_variable_count() > 0 {
@@ -462,7 +523,7 @@ impl Writer {
         if is_public_shim {
             // Write function call to the inner, internally-typed function.
             write!(out, "{INDENT}")?;
-            if self.config.use_global_struct() {
+            if self.config.functions_are_methods() {
                 write!(out, "self.")?;
             }
             write!(out, "{FN_INTERNAL_TYPES_PREFIX}{func_name}(")?;
@@ -722,8 +783,7 @@ impl Writer {
                     self.named_expressions.insert(expr, name);
                 }
 
-                // If we are using a global struct, then functions are methods of that struct.
-                if self.config.use_global_struct() {
+                if self.config.functions_are_methods() {
                     write!(out, "self.")?;
                 }
 
@@ -1257,8 +1317,14 @@ impl Writer {
                 });
             }
             Expression::GlobalVariable(handle) => {
-                let name = &self.names[&NameKey::GlobalVariable(handle)];
-                write!(out, "self.{name}")?;
+                write!(
+                    out,
+                    "{prefix}{name}",
+                    prefix = self
+                        .config
+                        .global_field_access_prefix(&module.global_variables[handle]),
+                    name = &self.names[&NameKey::GlobalVariable(handle)]
+                )?;
             }
 
             Expression::As {
@@ -1646,7 +1712,7 @@ impl Writer {
             space,
             binding: _, // don't (yet) expose numeric binding locations
             ty,
-            init: _,               // TODO: need to put initialize exprs in a new() fn
+            init: _,
             memory_decorations: _, // TODO: probably need to do things with this
         } = global;
 
@@ -1659,8 +1725,9 @@ impl Writer {
 
         write!(
             out,
-            "{INDENT}{}: ",
-            &self.names[&NameKey::GlobalVariable(handle)]
+            "{INDENT}{visibility}{name}: ",
+            visibility = self.visibility(),
+            name = &self.names[&NameKey::GlobalVariable(handle)],
         )?;
         self.write_type(out, module, ty, TypeTranslation::from(space))?;
         writeln!(out, ",")?;
@@ -1675,11 +1742,8 @@ impl Writer {
         global: &naga::GlobalVariable,
         handle: Handle<naga::GlobalVariable>,
     ) -> BackendResult {
-        write!(
-            out,
-            "{INDENT}{INDENT}{}: ",
-            &self.names[&NameKey::GlobalVariable(handle)]
-        )?;
+        let name: &str = &self.names[&NameKey::GlobalVariable(handle)];
+        write!(out, "{INDENT}{INDENT}{name}: ")?;
 
         if let Some(init) = global.init {
             self.write_expr(

--- a/back/tests/textual.rs
+++ b/back/tests/textual.rs
@@ -66,40 +66,6 @@ fn expect_unimplemented(wgsl_source_text: &str) {
 // -------------------------------------------------------------------------------------------------
 
 #[test]
-fn visibility_control() {
-    assert_eq!(
-        translate(Config::new(), "fn foo() {}"),
-        indoc::indoc! {
-            r"
-            fn foo() {
-                v_foo().into()
-            }
-            #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
-            fn v_foo() {
-                return;
-            }
-            
-            "
-        }
-    );
-    assert_eq!(
-        translate(Config::new().public_items(true), "fn foo() {}"),
-        indoc::indoc! {
-            r"
-            pub fn foo() {
-                v_foo().into()
-            }
-            #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
-            fn v_foo() {
-                return;
-            }
-            
-            "
-        }
-    );
-}
-
-#[test]
 fn entry_point() {
     assert_eq!(
         translate(
@@ -130,30 +96,210 @@ fn global_variable_enabled() {
     assert_eq!(
         translate(
             Config::new().global_struct("Globals"),
-            r"var<private> foo: i32 = 1;"
+            r"
+            var<private> foo: i32 = 1;
+            fn get_global() -> i32 { return foo; }
+            "
         ),
         indoc::indoc! {
             "
             struct Globals {
                 foo: ::naga_rust_rt::Scalar<i32>,
             }
-            impl Default for Globals {
-                fn default() -> Self { Self {
+            impl Globals {
+                const fn new() -> Self { Self {
                     foo: ::naga_rust_rt::Scalar(1i32),
                 }}
             }
+            impl Default for Globals { fn default() -> Self { Self::new() } }
             impl Globals {
+            fn get_global(&self, ) -> i32 {
+                self.v_get_global().into()
+            }
+            #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
+            fn v_get_global(&self, ) -> ::naga_rust_rt::Scalar<i32> {
+                let _e1 = self.foo;
+                return _e1;
+            }
+
             }
             "
         }
     );
 }
+
 #[test]
 fn global_variable_disabled() {
     assert!(matches!(
         expect_error(Config::new(), r"var<private> foo: i32 = 1;"),
         naga_rust_back::Error::GlobalVariablesNotEnabled { example: _, .. }
     ));
+}
+
+#[test]
+fn resources_enabled() {
+    assert_eq!(
+        translate(
+            Config::new().resource_struct("Resources"),
+            r"
+            @group(0) @binding(0) var<uniform> foo: i32;
+            fn get_uniform() -> i32 { return foo; }
+            "
+        ),
+        indoc::indoc! {
+            "
+            struct Resources {
+                // group(0) binding(0)
+                foo: ::naga_rust_rt::Scalar<i32>,
+            }
+            impl Resources {
+            fn get_uniform(&self, ) -> i32 {
+                self.v_get_uniform().into()
+            }
+            #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
+            fn v_get_uniform(&self, ) -> ::naga_rust_rt::Scalar<i32> {
+                let _e1 = self.foo;
+                return _e1;
+            }
+
+            }
+            "
+        }
+    );
+}
+
+#[test]
+fn resources_disabled() {
+    assert!(matches!(
+        expect_error(
+            Config::new(),
+            r"@group(0) @binding(0) var<uniform> foo: i32;"
+        ),
+        naga_rust_back::Error::ResourcesNotEnabled { example: _, .. }
+    ));
+}
+
+/// Code generated when both `global_struct` and `resource_struct` are set.
+///
+/// This test also tests the `public_items` option, because that affects globals and functions.
+#[test]
+fn globals_and_resources_enabled_and_visibility() {
+    let source = r"
+        @group(0) @binding(0) var<uniform> foo: i32;
+        var<private> bar: i32 = 1;
+        fn combine() -> i32 {
+            return foo + bar;
+        } 
+    ";
+
+    // Without public items
+    assert_eq!(
+        translate(
+            Config::new()
+                .global_struct("Globals")
+                .resource_struct("Resources"),
+            source
+        ),
+        indoc::indoc! {
+            "
+            struct Resources {
+                // group(0) binding(0)
+                foo: ::naga_rust_rt::Scalar<i32>,
+            }
+            struct Globals<'g> {
+                resources: &'g Resources,
+                bar: ::naga_rust_rt::Scalar<i32>,
+            }
+            impl<'g> Globals<'g> {
+                const fn new(resources: &'g Resources) -> Self { Self {
+                    resources,
+                    bar: ::naga_rust_rt::Scalar(1i32),
+                }}
+            }
+            impl<'g> Globals<'g> {
+            fn combine(&self, ) -> i32 {
+                self.v_combine().into()
+            }
+            #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
+            fn v_combine(&self, ) -> ::naga_rust_rt::Scalar<i32> {
+                let _e1 = self.resources.foo;
+                let _e3 = self.bar;
+                return (_e1 + _e3);
+            }
+
+            }
+            "
+        }
+    );
+
+    // With public items
+    assert_eq!(
+        translate(
+            Config::new()
+                .global_struct("Globals")
+                .resource_struct("Resources")
+                .public_items(true),
+            source
+        ),
+        indoc::indoc! {
+            "
+            struct Resources {
+                // group(0) binding(0)
+                pub foo: ::naga_rust_rt::Scalar<i32>,
+            }
+            struct Globals<'g> {
+                pub resources: &'g Resources,
+                pub bar: ::naga_rust_rt::Scalar<i32>,
+            }
+            impl<'g> Globals<'g> {
+                pub const fn new(resources: &'g Resources) -> Self { Self {
+                    resources,
+                    bar: ::naga_rust_rt::Scalar(1i32),
+                }}
+            }
+            impl<'g> Globals<'g> {
+            pub fn combine(&self, ) -> i32 {
+                self.v_combine().into()
+            }
+            #[allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)]
+            fn v_combine(&self, ) -> ::naga_rust_rt::Scalar<i32> {
+                let _e1 = self.resources.foo;
+                let _e3 = self.bar;
+                return (_e1 + _e3);
+            }
+
+            }
+            "
+        }
+    );
+}
+
+#[test]
+fn globals_and_resources_enabled_but_empty() {
+    assert_eq!(
+        translate(
+            Config::new()
+                .global_struct("Globals")
+                .resource_struct("Resources"),
+            r""
+        ),
+        indoc::indoc! {
+            "
+            struct Resources {
+            }
+            struct Globals<'g> {
+                resources: &'g Resources,
+            }
+            impl<'g> Globals<'g> {
+                const fn new(resources: &'g Resources) -> Self { Self {
+                    resources,
+                }}
+            }
+            impl<'g> Globals<'g> {
+            }
+            "
+        }
+    );
 }
 
 #[test]
@@ -218,11 +364,13 @@ fn array_type_sizes() {
     );
 }
 
+/// This test is only intending to check the translation of `arrayLength()`,
+/// but it needs a resource to be able to get a `ptr<storage, array<..>>`.
 #[test]
 fn array_length() {
     assert_eq!(
         translate(
-            Config::new().global_struct("Globals"),
+            Config::new().resource_struct("Resources"),
             r"
             @group(0) @binding(1) var<storage> arr: array<u32>;
             fn length() -> u32 {
@@ -230,22 +378,13 @@ fn array_length() {
             }
             ",
         ),
-        // TODO: we don't yet fully support bindings properly so lots of this code is nonsense.
-        // This test is only intending to check the translation of arrayLength(), which is
-        // hard to test separately since it must take a `ptr<storage, array<..>>`.
-        //
         indoc::indoc! {
             "
-            struct Globals {
+            struct Resources {
                 // group(0) binding(1)
                 arr: [::naga_rust_rt::Scalar<u32>],
             }
-            impl Default for Globals {
-                fn default() -> Self { Self {
-                    arr: Default::default(),
-                }}
-            }
-            impl Globals {
+            impl Resources {
             fn length(&self, ) -> u32 {
                 self.v_length().into()
             }
@@ -265,7 +404,7 @@ fn array_length() {
 fn atomic_type() {
     assert_eq!(
         translate(
-            Config::new().global_struct("Globals"),
+            Config::new().resource_struct("Resources"),
             r"
             @group(0) @binding(0)
             var<storage, read_write> atomic_scalar: atomic<u32>;
@@ -273,16 +412,11 @@ fn atomic_type() {
         ),
         indoc::indoc! {
             "
-            struct Globals {
+            struct Resources {
                 // group(0) binding(0)
                 atomic_scalar: ::core::sync::atomic::AtomicU32,
             }
-            impl Default for Globals {
-                fn default() -> Self { Self {
-                    atomic_scalar: Default::default(),
-                }}
-            }
-            impl Globals {
+            impl Resources {
             }
             "
         }

--- a/embed/README.md
+++ b/embed/README.md
@@ -13,7 +13,7 @@ use the [`naga-rust-back`] library directly instead.
 
 This library is in an early stage of development and many features do not work yet.
 Expect compilation failures and to have to tweak your code to fit.
-Broadly, simple mathematical functions will work, and bindings, textures, atomics,
+Broadly, simple mathematical functions will work, and matrices, textures, atomics,
 derivatives, and workgroup operations will not.
 
 [`naga`]: https://crates.io/crates/naga

--- a/embed/src/configuration_syntax.md
+++ b/embed/src/configuration_syntax.md
@@ -1,6 +1,14 @@
 The available configuration options are:
 
 * `global_struct = StructNameHere`:
-  Allow declarations of global variables, generate a struct with the given name to hold
+  Allow declarations of private global variables, generate a struct with the given name to hold
   them, and make all functions methods of that struct.
+
+  The struct has one constructor method, which is declared as either
+  `const fn new()` or `const fn new(resources: &ResourceStructName)`
+  depending on whether `resource_struct` is also set.
+  If there are no parameters, then it also implements [`Default`].
+* `resource_struct = StructNameHere`:
+  Allow declarations of resources (uniforms), generate a struct with the given name to hold
+  them, and make all functions methods of that struct if `global_struct` is not also set.
 * TODO: Other configuration options are not implemented.

--- a/embed/src/lib.rs
+++ b/embed/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! This library is in an early stage of development and many features do not work yet.
 //! Expect compilation failures and to have to tweak your code to fit.
-//! Broadly, simple mathematical functions will work, and bindings, textures, atomics,
+//! Broadly, simple mathematical functions will work, and matrices, textures, atomics,
 //! derivatives, and workgroup operations will not.
 //!
 //! # Example
@@ -83,7 +83,7 @@ pub use naga_rust_macros::include_wgsl_mr;
 ///     "var<private> foo: i32 = 10;",
 /// );
 ///
-/// assert_eq!(Globals::default().foo, naga_rust_embed::rt::Scalar(10));
+/// assert_eq!(Globals::new().foo, naga_rust_embed::rt::Scalar(10));
 /// ```
 ///
 #[doc = include_str!("configuration_syntax.md")]

--- a/embed/tests/interop/globals_and_functions.rs
+++ b/embed/tests/interop/globals_and_functions.rs
@@ -1,6 +1,6 @@
 //! Tests of `global_struct` or its absence, and of function calls from outside and inside.
 
-use naga_rust_embed::rt::{Vec2, Vec4};
+use naga_rust_embed::rt::{Scalar, Vec2, Vec4};
 use naga_rust_embed::wgsl;
 
 #[test]
@@ -56,13 +56,13 @@ pub(crate) fn function_call_with_self() {
         "
     );
 
-    assert_eq!(Globals::default().outer(), 1234);
+    assert_eq!(Globals::new().outer(), 1234);
 }
 
 #[test]
-pub(crate) fn global_uniform_binding() {
+pub(crate) fn uniform_binding() {
     wgsl!(
-        global_struct = Globals,
+        resource_struct = Resources,
         r"
         struct Uniforms {
             @location(0) x: f32,
@@ -77,15 +77,28 @@ pub(crate) fn global_uniform_binding() {
     "
     );
 
-    // TODO: impl Default is not the proper path for this -- codegen is unconditionally using
-    // Default for all globals. There should instead be a constructor for the Globals struct
-    // (...or, actually, a version of it which contains only bindings and not workgroup or private
-    // variables).
-    impl Default for Uniforms {
-        fn default() -> Self {
-            Uniforms { x: 1.0, y: 2.0 }
+    assert_eq!(
+        Resources {
+            ub: Uniforms { x: 1.0, y: 2.0 }
         }
-    }
+        .main(),
+        Vec2::new(1.0, 2.0)
+    )
+}
 
-    assert_eq!(Globals::default().main(), Vec2::new(1.0, 2.0))
+#[test]
+fn both_globals_and_resources() {
+    wgsl!(
+        global_struct = Globals,
+        resource_struct = Resources,
+        r"
+        @group(0) @binding(0) var<uniform> foo: i32;
+        var<private> bar: i32 = 1;
+        fn combine() -> i32 {
+            return foo + bar;
+        } 
+        "
+    );
+
+    assert_eq!(Globals::new(&Resources { foo: Scalar(100) }).combine(), 101);
 }

--- a/examples/render/src/main.rs
+++ b/examples/render/src/main.rs
@@ -15,7 +15,7 @@ use winit::window::{Window, WindowId};
 
 use naga_rust_embed::rt;
 
-naga_rust_embed::include_wgsl_mr!(global_struct = Shader, "src/shader.wgsl");
+naga_rust_embed::include_wgsl_mr!(resource_struct = Shader, "src/shader.wgsl");
 
 // -------------------------------------------------------------------------------------------------
 
@@ -52,8 +52,6 @@ fn run_fragment_shader(time: f32, buffer: &mut [u32], size: PhysicalSize<u32>) {
                 #[allow(clippy::cast_precision_loss)]
                 let fragment_position = rt::Vec4::new(x as f32, y as f32, 0.0, 0.0);
 
-                // TODO: There should be a nice constructor API for uniforms.
-                // Maybe a separate struct.
                 let result = Shader {
                     time: rt::Scalar(time),
                 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -83,6 +83,9 @@ impl syn::parse::Parse for ConfigAndStr {
                 "global_struct" => {
                     config = config.global_struct(input.parse::<syn::Ident>()?.to_string());
                 }
+                "resource_struct" => {
+                    config = config.resource_struct(input.parse::<syn::Ident>()?.to_string());
+                }
                 // TODO: implement other configuration options
                 _ => {
                     return Err(syn::Error::new_spanned(


### PR DESCRIPTION
Closes #10. 

* Add `resource_struct` option.
* Separate resources from global variables — resources must be provided externally, whereas global variables are initialized as specified by the shader code.
* Also fix `PUBLIC_ITEMS` not being a separate bitflag.