### PR TITLE
Add `Texture` trait and `textureLoad()` support.

### DIFF
--- a/back/src/lib.rs
+++ b/back/src/lib.rs
@@ -57,15 +57,6 @@ pub enum Error {
     // or fall into a well-defined category of unsupportedness.
     Unimplemented(String),
 
-    /// We don’t (yet) support texture operations in Rust,
-    /// and this is a notably broad category so it gets its own variant.
-    #[non_exhaustive]
-    TexturesAreUnsupported {
-        /// The specific kind of thing found that is unsupported.
-        /// Represented as a WGSL-flavored string.
-        found: &'static str,
-    },
-
     /// To use a shader with private global variables, [`Config::global_struct()`] must be set.
     #[non_exhaustive]
     GlobalVariablesNotEnabled {
@@ -93,9 +84,6 @@ impl fmt::Display for Error {
         match self {
             Error::FmtError(fmt::Error) => write!(f, "formatting cancelled"),
             Error::Unimplemented(msg) => write!(f, "not yet implemented for Rust: {msg}"),
-            Error::TexturesAreUnsupported { found } => {
-                write!(f, "texture operations, such as {found}, are not supported")
-            }
             Error::GlobalVariablesNotEnabled { example } => write!(
                 f,
                 "global variable `{example}` found in shader, but `global_struct` is not configured"

--- a/back/src/writer.rs
+++ b/back/src/writer.rs
@@ -269,10 +269,21 @@ impl Writer {
         }
 
         // If we are using resources, write the `struct` that contains them.
+        let any_resource_requires_lifetime = GlobalKind::Resource
+            .filter(&module.global_variables)
+            .any(|(_, global)| matches!(module.types[global.ty].inner, TypeInner::Image { .. }));
+        let resource_lifetime_generics = if any_resource_requires_lifetime {
+            "<'g>"
+        } else {
+            ""
+        };
         {
             let mut resource_iter = GlobalKind::Resource.filter(&module.global_variables);
             if let Some(ref resource_struct) = self.config.resource_struct {
-                writeln!(out, "struct {resource_struct} {{")?;
+                writeln!(
+                    out,
+                    "struct {resource_struct}{resource_lifetime_generics} {{"
+                )?;
                 for (handle, global) in resource_iter {
                     self.write_global_variable_as_struct_field(out, module, global, handle)?;
                 }
@@ -289,7 +300,9 @@ impl Writer {
             if self.config.global_struct.is_some() && self.config.resource_struct.is_some() {
                 "<'g>"
             } else {
-                ""
+                // We use the resource struct like it was the global struct if we have only the
+                // former, so the `impl` must use those generics.
+                resource_lifetime_generics
             };
         {
             let mut global_variable_iter = GlobalKind::Variable.filter(&module.global_variables);
@@ -299,7 +312,8 @@ impl Writer {
                 if let Some(ref resource_struct_name) = self.config.resource_struct {
                     writeln!(
                         out,
-                        "{INDENT}{visibility}resources: &'g {resource_struct_name},"
+                        "{INDENT}{visibility}resources: \
+                            &'g {resource_struct_name}{resource_lifetime_generics},"
                     )?;
                 }
                 for (handle, global) in global_variable_iter {
@@ -314,7 +328,10 @@ impl Writer {
                 // Define new() function with parameter list depending on whether the resource
                 // struct is needed.
                 if let Some(ref resource_struct_name) = self.config.resource_struct {
-                    write!(out, "resources: &'g {resource_struct_name}")?;
+                    write!(
+                        out,
+                        "resources: &'g {resource_struct_name}{resource_lifetime_generics}"
+                    )?;
                 }
                 writeln!(out, ") -> Self {{ Self {{")?;
 
@@ -1320,19 +1337,74 @@ impl Writer {
                 }
             }
             Expression::ImageSample { .. } => {
-                return Err(Error::TexturesAreUnsupported {
-                    found: "textureSample",
-                });
+                self.write_unimplemented_expr(out, "texture sampling (other than textureLoad)")?;
             }
-            Expression::ImageQuery { .. } => {
-                return Err(Error::TexturesAreUnsupported {
-                    found: "texture queries",
-                });
-            }
-            Expression::ImageLoad { .. } => {
-                return Err(Error::TexturesAreUnsupported {
-                    found: "textureLoad",
-                });
+            Expression::ImageQuery { image, query } => match query {
+                naga::ImageQuery::Size { level } => {
+                    write!(out, "{runtime_path}::Texture::dimensions(")?;
+                    self.write_expr(out, image, expr_ctx)?;
+                    write!(out, ", ")?;
+                    if let Some(level) = level {
+                        write!(out, "{runtime_path}::Scalar::<i32>::into_inner(")?;
+                        self.write_expr(out, level, expr_ctx)?;
+                        write!(out, ")")?;
+                    } else {
+                        write!(out, "0")?;
+                    }
+                    write!(out, ")")?;
+                }
+                naga::ImageQuery::NumLevels => {
+                    write!(out, "{runtime_path}::Texture::mip_levels(")?;
+                    self.write_expr(out, image, expr_ctx)?;
+                    write!(out, ")")?;
+                }
+                naga::ImageQuery::NumLayers => {
+                    write!(out, "{runtime_path}::Texture::array_layers(")?;
+                    self.write_expr(out, image, expr_ctx)?;
+                    write!(out, ")")?;
+                }
+                naga::ImageQuery::NumSamples => {
+                    write!(out, "{runtime_path}::Texture::samples(")?;
+                    self.write_expr(out, image, expr_ctx)?;
+                    write!(out, ")")?;
+                }
+            },
+            Expression::ImageLoad {
+                image,
+                coordinate,
+                array_index,
+                sample,
+                level,
+            } => {
+                write!(out, "{runtime_path}::Texture::load(")?;
+                self.write_expr(out, image, expr_ctx)?;
+                write!(out, ", ")?;
+                self.write_expr(out, coordinate, expr_ctx)?;
+                write!(out, ", ")?;
+                if let Some(array_index) = array_index {
+                    write!(out, "{runtime_path}::Scalar::<i32>::into_inner(")?;
+                    self.write_expr(out, array_index, expr_ctx)?;
+                    write!(out, ")")?;
+                } else {
+                    write!(out, "0")?;
+                }
+                write!(out, ", ")?;
+                if let Some(sample) = sample {
+                    write!(out, "{runtime_path}::Scalar::<i32>::into_inner(")?;
+                    self.write_expr(out, sample, expr_ctx)?;
+                    write!(out, ")")?;
+                } else {
+                    write!(out, "0")?;
+                }
+                write!(out, ", ")?;
+                if let Some(level) = level {
+                    write!(out, "{runtime_path}::Scalar::<i32>::into_inner(")?;
+                    self.write_expr(out, level, expr_ctx)?;
+                    write!(out, ")")?;
+                } else {
+                    write!(out, "0")?;
+                }
+                write!(out, ")")?;
             }
             Expression::GlobalVariable(handle) => {
                 write!(
@@ -1653,8 +1725,29 @@ impl Writer {
             TypeInner::Sampler { comparison: true } => {
                 write!(out, "{runtime_path}::SamplerComparison")?;
             }
-            TypeInner::Image { .. } => {
-                write!(out, "{runtime_path}::Image")?;
+            TypeInner::Image {
+                dim,
+                arrayed: _, // TODO: support array textures
+                class: _,   // TODO: might want separate traits per class
+            } => {
+                // TODO: we will want to support statically dispatched texture access,
+                // but that will require more generics work on the resource struct.
+                // `dyn` is a placeholder for further work.
+                let vec = match dim {
+                    naga::ImageDimension::D1 => "Scalar",
+                    naga::ImageDimension::D2 => "Vec2",
+                    naga::ImageDimension::D3 => "Vec3",
+                    naga::ImageDimension::Cube => "Vec3",
+                };
+                write!(
+                    out,
+                    // 'g is a lifetime name which is declared on the global struct *and* the
+                    // resource struct.
+                    "&'g dyn {runtime_path}::Texture<\
+                        Dimensions = {runtime_path}::{vec}<u32>,\
+                        Coordinates = {runtime_path}::{vec}<i32>,\
+                    >",
+                )?;
             }
             TypeInner::Atomic(scalar) => {
                 write!(

--- a/back/tests/textual.rs
+++ b/back/tests/textual.rs
@@ -175,6 +175,7 @@ fn resources_disabled() {
 fn globals_and_resources_enabled_and_visibility() {
     let source = r"
         @group(0) @binding(0) var<uniform> foo: i32;
+        @group(0) @binding(1) var texture: texture_2d<f32>;
         var<private> bar: i32 = 1;
         fn combine() -> i32 {
             return foo + bar;
@@ -191,16 +192,18 @@ fn globals_and_resources_enabled_and_visibility() {
         ),
         indoc::indoc! {
             "
-            struct Resources {
+            struct Resources<'g> {
                 // group(0) binding(0)
                 foo: ::naga_rust_rt::Scalar<i32>,
+                // group(0) binding(1)
+                texture: &'g dyn ::naga_rust_rt::Texture<Dimensions = ::naga_rust_rt::Vec2<u32>,Coordinates = ::naga_rust_rt::Vec2<i32>,>,
             }
             struct Globals<'g> {
-                resources: &'g Resources,
+                resources: &'g Resources<'g>,
                 bar: ::naga_rust_rt::Scalar<i32>,
             }
             impl<'g> Globals<'g> {
-                const fn new(resources: &'g Resources) -> Self { Self {
+                const fn new(resources: &'g Resources<'g>) -> Self { Self {
                     resources,
                     bar: ::naga_rust_rt::Scalar(1i32),
                 }}
@@ -232,16 +235,18 @@ fn globals_and_resources_enabled_and_visibility() {
         ),
         indoc::indoc! {
             "
-            struct Resources {
+            struct Resources<'g> {
                 // group(0) binding(0)
                 pub foo: ::naga_rust_rt::Scalar<i32>,
+                // group(0) binding(1)
+                pub texture: &'g dyn ::naga_rust_rt::Texture<Dimensions = ::naga_rust_rt::Vec2<u32>,Coordinates = ::naga_rust_rt::Vec2<i32>,>,
             }
             struct Globals<'g> {
-                pub resources: &'g Resources,
+                pub resources: &'g Resources<'g>,
                 pub bar: ::naga_rust_rt::Scalar<i32>,
             }
             impl<'g> Globals<'g> {
-                pub const fn new(resources: &'g Resources) -> Self { Self {
+                pub const fn new(resources: &'g Resources<'g>) -> Self { Self {
                     resources,
                     bar: ::naga_rust_rt::Scalar(1i32),
                 }}

--- a/embed/tests/interop/main.rs
+++ b/embed/tests/interop/main.rs
@@ -7,6 +7,7 @@ mod globals_and_functions;
 mod matrices;
 mod operators;
 mod structs;
+mod textures;
 mod vector_construction;
 
 // -------------------------------------------------------------------------------------------------

--- a/embed/tests/interop/textures.rs
+++ b/embed/tests/interop/textures.rs
@@ -1,0 +1,80 @@
+use core::num::NonZeroU32;
+
+use naga_rust_embed::rt::{self, Vec2, Vec4};
+use naga_rust_embed::wgsl;
+
+#[test]
+fn texture_query_and_load() {
+    struct MyTexture;
+    impl rt::Texture for MyTexture {
+        type Dimensions = Vec2<u32>;
+        type Coordinates = Vec2<i32>;
+
+        fn dimensions(&self, _mip_level: i32) -> Self::Dimensions {
+            Vec2::new(100, 100)
+        }
+
+        fn array_layers(&self) -> NonZeroU32 {
+            NonZeroU32::MIN
+        }
+
+        fn mip_levels(&self) -> NonZeroU32 {
+            NonZeroU32::MIN
+        }
+
+        fn samples(&self) -> NonZeroU32 {
+            NonZeroU32::MIN
+        }
+
+        fn load(
+            &self,
+            coordinates: Self::Coordinates,
+            _array_layer: i32,
+            _sample: i32,
+            mip_level: i32,
+        ) -> Vec4<f32> {
+            assert_eq!(coordinates, Vec2::new(10, 20));
+            assert_eq!(mip_level, 0);
+            Vec4::new(1.0, 2.0, 3.0, 4.0)
+        }
+    }
+
+    // TODO: for full coverage, we need many different texture binding types and their corresponding
+    // call overloads.
+    wgsl!(
+        resource_struct = Resources,
+        r"
+        @group(0) @binding(0) var my_texture: texture_2d<f32>;
+        fn dimensions() -> vec2u {
+            return textureDimensions(my_texture, 0);
+        }
+        fn load(position: vec2i) -> vec4f {
+            return textureLoad(my_texture, position, 0);
+        }"
+    );
+
+    let res = Resources {
+        my_texture: &MyTexture,
+    };
+    assert_eq!(res.dimensions(), Vec2::new(100u32, 100));
+    assert_eq!(res.load(Vec2::new(10, 20)), Vec4::new(1.0, 2.0, 3.0, 4.0));
+}
+
+/// We don’t implement texture sampling yet, but shaders that mentions samplers should still be
+/// compilable.
+#[test]
+fn sampler() {
+    wgsl!(
+        resource_struct = Resources,
+        "
+        @group(0) @binding(0) var my_sampler: sampler;
+        fn unrelated_function() {}
+        "
+    );
+
+    // This should run without error (it does not use the sampler binding).
+    Resources {
+        my_sampler: rt::Sampler,
+    }
+    .unrelated_function();
+}

--- a/rt/src/lib.rs
+++ b/rt/src/lib.rs
@@ -14,9 +14,11 @@
 extern crate std;
 
 mod matrix;
+mod texture;
 mod vector;
 
 pub use matrix::*;
+pub use texture::*;
 pub use vector::*;
 
 // TODO: should probably be num_traits::Zero or something custom

--- a/rt/src/texture.rs
+++ b/rt/src/texture.rs
@@ -1,0 +1,51 @@
+use core::num::NonZeroU32;
+
+use crate::Vec4;
+
+/// Texture sampler (placeholder).
+///
+/// Use this type to satisfy a sampler binding in a resource struct.
+pub struct Sampler;
+
+// TODO: Consider, instead of putting all the metadata as methods on the Txture trait,
+// defining a struct with the metadata. This ensures consistency (particularly for things like
+// per-mip-level dimensions) and avoids ever using dynamic dispatch, at the price of possibly
+// duplicating some integers.
+
+/// Implement this trait to provide a texture to the shader code.
+// TODO: This will need expansion to handle depth textures
+pub trait Texture {
+    /// Type of the dimensions of the texture.
+    /// Should be a [`Scalar`][crate::Scalar], [`Vec2`][crate::Vec2], or [`Vec3`][crate::Vec3]
+    /// of `u32`.
+    type Dimensions: Copy + 'static;
+
+    /// Type of a point within the texture.
+    /// Should be a [`Scalar`][crate::Scalar], [`Vec2`][crate::Vec2], or [`Vec3`][crate::Vec3]
+    /// of `i32`.
+    type Coordinates: Copy + 'static;
+
+    /// Returns the dimensions of the texture.
+    fn dimensions(&self, mip_level: i32) -> Self::Dimensions;
+
+    /// Returns the count of array layers of the texture.
+    fn array_layers(&self) -> NonZeroU32;
+
+    /// Returns the count of mip levels of the texture.
+    fn mip_levels(&self) -> NonZeroU32;
+
+    /// Returns the count of samples of the texture.
+    fn samples(&self) -> NonZeroU32;
+
+    /// Loads a single texel from the texture.
+    ///
+    /// If the coordinates are out of bounds, do not panic, but perform one of the behaviors
+    /// specified in <https://www.w3.org/TR/WGSL/#textureload>.
+    fn load(
+        &self,
+        coordinates: Self::Coordinates,
+        array_layer: i32,
+        sample: i32,
+        mip_level: i32,
+    ) -> Vec4<f32>;
+}


### PR DESCRIPTION
Part of #9.

Missing features:
* Static dispatch to the texture implementation (currently, only `dyn Texture` is allowed).
* Texture sampling (use of `textureSample()` and a sampler).
* Cube map and depth textures.