### PR TITLE
Add `allow_unimplemented` option to make missing features non-fatal.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,6 +754,7 @@ dependencies = [
  "naga",
  "once_cell",
  "pretty_assertions",
+ "proc-macro2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ num-traits = { version = "0.2.19", default-features = false }
 once_cell = { version = "1.21.3", default-features = false }
 paste = {version = "1.0.15", default-features = false }
 pretty_assertions = { version = "1.2.0" }
+proc-macro2 = { version = "1.0.91", default-features = false }
 
 [workspace.lints.rust]
 # rustc lints that are set to deny

--- a/back/Cargo.toml
+++ b/back/Cargo.toml
@@ -24,6 +24,8 @@ arrayvec = { workspace = true }
 bitflags = { workspace = true }
 naga = { workspace = true }
 once_cell = { workspace = true }
+# Used to quote Rust string literals
+proc-macro2.workspace = true
 
 [dev-dependencies]
 # Use WGSL frontend and Rust backend to run tests/textual.rs

--- a/back/src/config.rs
+++ b/back/src/config.rs
@@ -70,6 +70,18 @@ impl Config {
         self
     }
 
+    /// Sets whether to allow the generated code to panic on entering code that cannot be
+    /// translated, rather than failing generation.
+    ///
+    /// This applies to all unsupported expressions and statements, but not to unsupported types.
+    ///
+    /// The default is `false`.
+    #[must_use]
+    pub fn allow_unimplemented(mut self, value: bool) -> Self {
+        self.flags.set(WriterFlags::ALLOW_UNIMPLEMENTED, value);
+        self
+    }
+
     /// Sets the Rust module path to the runtime support library.
     ///
     /// The default is `"::naga_rust_rt"`.
@@ -164,6 +176,10 @@ bitflags::bitflags! {
 
         /// Generate items with `pub` visibility instead of private.
         const PUBLIC = 0x4;
+
+        /// Allow the generated code to panic on entering code that cannot be
+        /// translated, rather than failing generation.
+        const ALLOW_UNIMPLEMENTED = 0x8;
     }
 }
 

--- a/back/src/writer.rs
+++ b/back/src/writer.rs
@@ -239,7 +239,7 @@ impl Writer {
         info: &ModuleInfo,
     ) -> BackendResult {
         if !module.overrides.is_empty() {
-            return Err(Error::Unimplemented("pipeline constants".into()));
+            self.write_unimplemented_stmt(out, "pipeline constants")?;
         }
 
         self.reset(module);
@@ -606,7 +606,14 @@ impl Writer {
                         // `clippy::all` refers to all *default* clippy lints, not all clippy lints.
                         // We’re allowing all clippy categories except for restriction, which we
                         // shall assume is on purpose, and cargo, which is irrelvant.
-                        "allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery)"
+                        "allow(unused_parens, clippy::all, clippy::pedantic, clippy::nursery{})",
+                        if self.config.flags.contains(WriterFlags::ALLOW_UNIMPLEMENTED) {
+                            // ALLOW_UNIMPLEMENTED generates `panic!()`s which will often be
+                            // followed by code that is therefore unreachable.
+                            ", unreachable_code"
+                        } else {
+                            ""
+                        }
                     )?;
                 }
                 Attribute::Stage(shader_stage) => {
@@ -801,20 +808,16 @@ impl Writer {
                 writeln!(out, ");")?
             }
             Statement::Atomic { .. } => {
-                return Err(Error::Unimplemented("atomic operations".into()));
+                self.write_unimplemented_stmt(out, "atomic operations")?;
             }
             Statement::ImageAtomic { .. } => {
-                return Err(Error::TexturesAreUnsupported {
-                    found: "textureAtomic",
-                });
+                self.write_unimplemented_stmt(out, "atomic texture operations")?;
             }
             Statement::WorkGroupUniformLoad { .. } => {
                 todo!("Statement::WorkGroupUniformLoad");
             }
             Statement::ImageStore { .. } => {
-                return Err(Error::TexturesAreUnsupported {
-                    found: "textureStore",
-                });
+                self.write_unimplemented_stmt(out, "textureStore")?;
             }
             Statement::Block(ref block) => {
                 write!(out, "{level}")?;
@@ -838,13 +841,6 @@ impl Writer {
                 let l2 = level.next();
                 let mut new_match_arm = true;
                 for case in cases {
-                    if case.fall_through && !case.body.is_empty() {
-                        // TODO
-                        return Err(Error::Unimplemented(
-                            "fall-through switch case block".into(),
-                        ));
-                    }
-
                     if new_match_arm {
                         // Write initial indentation.
                         write!(out, "{l2}")?;
@@ -865,7 +861,7 @@ impl Writer {
                         }
                     }
 
-                    new_match_arm = !case.fall_through;
+                    new_match_arm = !(case.fall_through && case.body.is_empty());
 
                     // End this pattern and begin the body of this arm,
                     // if it is not fall-through.
@@ -874,6 +870,12 @@ impl Writer {
                         for sta in case.body.iter() {
                             self.write_stmt(out, module, sta, func_ctx, l2.next())?;
                         }
+
+                        if case.fall_through && !case.body.is_empty() {
+                            // TODO
+                            self.write_unimplemented_stmt(out, "switch case with fall-through")?;
+                        }
+
                         writeln!(out, "{l2}}}")?;
                     }
                 }
@@ -917,18 +919,18 @@ impl Writer {
             Statement::Break => writeln!(out, "{level}break 'naga_break;")?,
             Statement::Continue => writeln!(out, "{level}break 'naga_continue;")?,
             Statement::ControlBarrier(_) | Statement::MemoryBarrier(_) => {
-                return Err(Error::Unimplemented("barriers".into()));
+                self.write_unimplemented_stmt(out, "barriers")?;
             }
             Statement::RayQuery { .. } | Statement::RayPipelineFunction(_) => {
-                return Err(Error::Unimplemented("raytracing".into()));
+                self.write_unimplemented_stmt(out, "raytracing")?;
             }
             Statement::SubgroupBallot { .. }
             | Statement::SubgroupCollectiveOperation { .. }
             | Statement::SubgroupGather { .. } => {
-                return Err(Error::Unimplemented("workgroup operations".into()));
+                self.write_unimplemented_stmt(out, "workgroup operations")?;
             }
             Statement::CooperativeStore { .. } => {
-                return Err(Error::Unimplemented("cooperative store".into()));
+                self.write_unimplemented_stmt(out, "cooperative store")?;
             }
         }
 
@@ -963,7 +965,8 @@ impl Writer {
             // When they *are* supported, they will be distinct because per Rust mutability rules,
             // we don’t need to obtain a mutable place, so it will suffice to just evaluate the
             // pointer expression and call an atomic operation function on it.
-            return Err(Error::Unimplemented("atomic operations".into()));
+            self.write_unimplemented_stmt(out, "atomic operations")?;
+            return Ok(());
         }
 
         if let Expression::AccessIndex { base, index } = *pointer_expr {
@@ -1455,7 +1458,7 @@ impl Writer {
                 write!(out, ")")?
             }
             Expression::Derivative { .. } => {
-                return Err(Error::Unimplemented("derivatives".into()));
+                self.write_unimplemented_expr(out, "derivatives")?;
 
                 // use naga::{DerivativeAxis as Axis, DerivativeControl as Ctrl};
                 // let op = match (axis, ctrl) {
@@ -1823,6 +1826,39 @@ impl Writer {
         )?;
         writeln!(out, ";")?;
 
+        Ok(())
+    }
+
+    /// For a feature that naga-rust does not support, either return an immediate conversion error, or emit
+    /// an expression that panics when executed.
+    fn write_unimplemented_expr(
+        &self,
+        out: &mut dyn Write,
+        unimplemented_feature: &'static str,
+    ) -> BackendResult {
+        if self.config.flags.contains(WriterFlags::ALLOW_UNIMPLEMENTED) {
+            write!(
+                out,
+                "unimplemented!({message})",
+                message = proc_macro2::Literal::string(&alloc::format!(
+                    "this shader function contains a feature which \
+                    cannot yet be translated to Rust, {unimplemented_feature}"
+                ))
+            )?;
+            Ok(())
+        } else {
+            Err(Error::Unimplemented(unimplemented_feature.into()))
+        }
+    }
+
+    fn write_unimplemented_stmt(
+        &self,
+        out: &mut dyn Write,
+        unimplemented_feature: &'static str,
+    ) -> BackendResult {
+        write!(out, "{INDENT}")?;
+        self.write_unimplemented_expr(out, unimplemented_feature)?;
+        writeln!(out, ";")?;
         Ok(())
     }
 

--- a/back/tests/textual.rs
+++ b/back/tests/textual.rs
@@ -293,6 +293,7 @@ fn globals_and_resources_enabled_but_empty() {
 
 #[test]
 fn switch() {
+    // TODO: we can’t fully exercise `fall_through` without using an input syntax other than WGSL
     assert_eq!(
         translate(
             Config::new(),

--- a/embed/src/configuration_syntax.md
+++ b/embed/src/configuration_syntax.md
@@ -11,4 +11,8 @@ The available configuration options are:
 * `resource_struct = StructNameHere`:
   Allow declarations of resources (uniforms), generate a struct with the given name to hold
   them, and make all functions methods of that struct if `global_struct` is not also set.
+* `allow_unimplemented = true | false`:
+  Whether to allow the generated code to panic on entering code that cannot be
+  translated, rather than failing generation.
+
 * TODO: Other configuration options are not implemented.

--- a/embed/tests/interop/main.rs
+++ b/embed/tests/interop/main.rs
@@ -9,6 +9,10 @@ mod operators;
 mod structs;
 mod vector_construction;
 
+// -------------------------------------------------------------------------------------------------
+
+use naga_rust_embed::wgsl;
+
 // TODO: implement atomics
 // #[test]
 // fn atomics() {
@@ -31,3 +35,24 @@ mod vector_construction;
 //     globals.atomic_ops();
 //     assert_eq!(globals.x.load(core::sync::atomic::Ordering::Relaxed), 36);
 // }
+
+#[test]
+fn allowed_unimplemented() {
+    wgsl!(
+        allow_unimplemented = true,
+        r"
+        fn example(x: f32) -> f32 {
+            return dpdx(x);
+        }
+        "
+    );
+
+    let result = std::panic::catch_unwind(|| {
+        example(1.0);
+    });
+    assert_eq!(
+        result.unwrap_err().downcast_ref::<&str>().unwrap(),
+        &"not implemented: this shader function contains a feature \
+            which cannot yet be translated to Rust, derivatives"
+    );
+}

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 [dependencies]
 naga = { workspace = true, features = ["wgsl-in"] }
 naga-rust-back.workspace = true
-proc-macro2 = "1.0.91"
+proc-macro2.workspace = true
 quote = "1.0.37"
 syn = { version = "2.0.100", default-features = false, features = ["parsing"] }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -86,6 +86,9 @@ impl syn::parse::Parse for ConfigAndStr {
                 "resource_struct" => {
                     config = config.resource_struct(input.parse::<syn::Ident>()?.to_string());
                 }
+                "allow_unimplemented" => {
+                    config = config.allow_unimplemented(input.parse::<syn::LitBool>()?.value);
+                }
                 // TODO: implement other configuration options
                 _ => {
                     return Err(syn::Error::new_spanned(


### PR DESCRIPTION
This makes it possible to run shader code that has unimplemented parts as long as they aren’t executed.