### PR TITLE
Add `ConstantTexture`, a stub texture implementation, and freshen documentation about what works.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,14 @@ Development status
 
 These libraries are in an early stage of development and many features do not work yet.
 Expect compilation failures, incorrect behaviors, and to have to tweak your code to fit,
-if you wish to use them.
-Broadly, simple mathematical functions will work, and matrices, textures, atomics,
-derivatives, and workgroup operations will not.
+if you wish to use them. Broadly:
 
+* Simple mathematical functions will work.
+* Code involving pointers is likely to fail to compile.
+* Textures are supported but texture filtering is not.
+* Atomics, derivatives, and workgroup operations are not supported.
+* Pipelines involving multiple shaders (e.g. passing data from vertex to fragment)
+  are not automatically executed but you can build that yourself.
 
 License
 -------

--- a/back/README.md
+++ b/back/README.md
@@ -8,10 +8,16 @@ The generated code requires the [`naga-rust-rt`] library.
 Alternatively, you can use [`naga-rust-embed`], which combines this library with [`naga-rust-rt`]
 and provides convenient macros for embedding translated WGSL in your Rust code.
 
-This library is in an early stage of development and many features do not work yet;
-this may be indicated by returned errors or by the generated code failing to compile.
-Broadly, simple mathematical functions will work, and bindings, textures, atomics,
-derivatives, and workgroup operations will not.
+This library is in an early stage of development and many features do not work yet.
+Expect compilation failures, incorrect behaviors, and to have to tweak your code to fit,
+if you wish to use them. Broadly:
+
+* Simple mathematical functions will work.
+* Code involving pointers is likely to fail to compile.
+* Textures are supported but texture filtering is not.
+* Atomics, derivatives, and workgroup operations are not supported.
+* Pipelines involving multiple shaders (e.g. passing data from vertex to fragment)
+  are not automatically executed but you can build that yourself.
 
 [`naga`]: https://crates.io/crates/naga
 [`naga-rust-rt`]: https://crates.io/crates/naga-rust-rt

--- a/back/src/lib.rs
+++ b/back/src/lib.rs
@@ -5,10 +5,16 @@
 //! Alternatively, you can use [`naga_rust_embed`], which combines this library with
 //! [`naga_rust_rt`] and provides convenient macros for embedding translated WGSL in your Rust code.
 //!
-//! This library is in an early stage of development and many features do not work yet;
-//! this may be indicated by returned errors or by the generated code failing to compile.
-//! Broadly, simple mathematical functions will work, and matrices, textures, atomics,
-//! derivatives, and workgroup operations will not.
+//! This library is in an early stage of development and many features do not work yet.
+//! Expect compilation failures, incorrect behaviors, and to have to tweak your code to fit,
+//! if you wish to use it. Broadly:
+//!
+//! * Simple mathematical functions will work.
+//! * Code involving pointers is likely to fail to compile.
+//! * Textures are supported but texture filtering is not.
+//! * Atomics, derivatives, and workgroup operations are not supported.
+//! * Pipelines involving multiple shaders (e.g. passing data from vertex to fragment)
+//!   are not automatically executed but you can build that yourself.
 //!
 //! [`naga_rust_rt`]: https://docs.rs/naga-rust-rt
 //! [`naga_rust_embed`]: https://docs.rs/naga-rust-embed

--- a/embed/README.md
+++ b/embed/README.md
@@ -12,9 +12,15 @@ If you need additional control over the translation or to use a different source
 use the [`naga-rust-back`] library directly instead.
 
 This library is in an early stage of development and many features do not work yet.
-Expect compilation failures and to have to tweak your code to fit.
-Broadly, simple mathematical functions will work, and matrices, textures, atomics,
-derivatives, and workgroup operations will not.
+Expect compilation failures, incorrect behaviors, and to have to tweak your code to fit,
+if you wish to use them. Broadly:
+
+* Simple mathematical functions will work.
+* Code involving pointers is likely to fail to compile.
+* Textures are supported but texture filtering is not.
+* Atomics, derivatives, and workgroup operations are not supported.
+* Pipelines involving multiple shaders (e.g. passing data from vertex to fragment)
+  are not automatically executed but you can build that yourself.
 
 [`naga`]: https://crates.io/crates/naga
 [`naga-rust-back`]: https://crates.io/crates/naga-rust-back

--- a/embed/src/lib.rs
+++ b/embed/src/lib.rs
@@ -9,9 +9,15 @@
 //! use the [`naga_rust_back`] library directly instead.
 //!
 //! This library is in an early stage of development and many features do not work yet.
-//! Expect compilation failures and to have to tweak your code to fit.
-//! Broadly, simple mathematical functions will work, and matrices, textures, atomics,
-//! derivatives, and workgroup operations will not.
+//! Expect compilation failures, incorrect behaviors, and to have to tweak your code to fit,
+//! if you wish to use it. Broadly:
+//!
+//! * Simple mathematical functions will work.
+//! * Code involving pointers is likely to fail to compile.
+//! * Textures are supported but texture filtering is not.
+//! * Atomics, derivatives, and workgroup operations are not supported.
+//! * Pipelines involving multiple shaders (e.g. passing data from vertex to fragment)
+//!   are not automatically executed but you can build that yourself.
 //!
 //! # Example
 //!

--- a/rt/src/texture.rs
+++ b/rt/src/texture.rs
@@ -1,6 +1,7 @@
+use core::marker::PhantomData;
 use core::num::NonZeroU32;
 
-use crate::Vec4;
+use crate::{Vec2, Vec3, Vec4};
 
 /// Texture sampler (placeholder).
 ///
@@ -54,4 +55,65 @@ pub trait Texture {
         sample: i32,
         mip_level: i32,
     ) -> Vec4<Self::Scalar>;
+}
+
+/// A [`Texture`] whose texels all have a single value.
+pub struct ConstantTexture<D: Copy + 'static, C: Copy + 'static, S> {
+    pub dimensions: D,
+    pub coordinates: PhantomData<fn(C)>,
+    pub texel: Vec4<S>,
+}
+
+impl<S: Copy> ConstantTexture<Vec2<u32>, Vec2<i32>, S> {
+    pub const fn new_2d(dimensions: Vec2<u32>, texel: Vec4<S>) -> Self {
+        Self {
+            dimensions,
+            coordinates: PhantomData,
+            texel,
+        }
+    }
+}
+
+impl<S: Copy> ConstantTexture<Vec3<u32>, Vec3<i32>, S> {
+    pub const fn new_3d(dimensions: Vec3<u32>, texel: Vec4<S>) -> Self {
+        Self {
+            dimensions,
+            coordinates: PhantomData,
+            texel,
+        }
+    }
+}
+
+impl<D: Copy + 'static, C: Copy + 'static, S: Copy> Texture for ConstantTexture<D, C, S> {
+    type Dimensions = D;
+
+    type Coordinates = C;
+
+    type Scalar = S;
+
+    fn dimensions(&self, _mip_level: i32) -> Self::Dimensions {
+        self.dimensions
+    }
+
+    fn array_layers(&self) -> NonZeroU32 {
+        NonZeroU32::MIN
+    }
+
+    fn mip_levels(&self) -> NonZeroU32 {
+        NonZeroU32::MIN
+    }
+
+    fn samples(&self) -> NonZeroU32 {
+        NonZeroU32::MIN
+    }
+
+    fn load(
+        &self,
+        _coordinates: Self::Coordinates,
+        _array_layer: i32,
+        _sample: i32,
+        _mip_level: i32,
+    ) -> Vec4<Self::Scalar> {
+        self.texel
+    }
 }


### PR DESCRIPTION
This is useful as a placeholder to get shaders working when you don’t need a complex texture input.