### PR TITLE
Define textures in terms of a set of predefined `Texture*` structs.

### DIFF
--- a/back/CHANGELOG.md
+++ b/back/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 * Support for matrices.
+* Support for texture loads (but not yet filtering).
 * Support for `continuing` and `break if` control flow.
 * Support for boolean vector functions `any()`, `all()`, and `select()`.
 * Partial support for additional math functions, such as `cross()` and `smoothstep()`.

--- a/back/src/ra.rs
+++ b/back/src/ra.rs
@@ -47,10 +47,12 @@ pub(crate) enum Type {
     Atomic(Scalar),
     /// Rust scalar type, e.g. [`u32`].
     BareScalar(Scalar),
-    /// Texture/image.
+    /// Texture/image handle.
     Texture {
         dim: naga::ImageDimension,
         scalar: Scalar,
+        multisampled: bool,
+        arrayed: bool,
     },
     /// Texture sampler.
     Sampler,
@@ -91,7 +93,7 @@ pub(crate) enum PtrKind {
 /// A type that is a scalar both in Rust terms and shader terms.
 ///
 /// These are a subset of [`Type`] because they appear in particular situations like atomics.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub(crate) enum Scalar {
     Bool,
     F32,
@@ -467,20 +469,38 @@ impl PrintAst for Type {
                 }
             ),
             Type::BareScalar(scalar) => write!(out, "{scalar}"),
-            Type::Texture { dim, scalar } => {
-                let vec = match dim {
-                    naga::ImageDimension::D1 => "Scalar",
-                    naga::ImageDimension::D2 => "Vec2",
-                    naga::ImageDimension::D3 => "Vec3",
-                    naga::ImageDimension::Cube => "Vec3",
+            &Type::Texture {
+                dim,
+                scalar,
+                multisampled,
+                arrayed,
+            } => {
+                let (dim_string, vec) = match dim {
+                    naga::ImageDimension::D1 => ("1d", "Scalar"),
+                    naga::ImageDimension::D2 => ("2d", "Vec2"),
+                    naga::ImageDimension::D3 => ("3d", "Vec3"),
+                    naga::ImageDimension::Cube => ("Cube", "Vec3"),
                 };
+                // TODO: we want to support fully statically dispatched texture access,
+                // but that will require more work to either:
+                //
+                // * allow the user to specify a concrete type for the texture storage,
+                // * make the resource struct generic,
+                // * or allow the user to provide their own resource struct (possibly corresponding
+                //   to a single bind group) and adapt to its types.
+                //
+                // `dyn` is a placeholder for further work, and it’s not great to go through
+                // a dynamic dispatch for every texel load.
                 write!(
                     out,
-                    "&'g dyn {runtime_path}::Texture<\
-                        Dimensions = {runtime_path}::{vec}<u32>,\
-                        Coordinates = {runtime_path}::{vec}<i32>,\
-                        Scalar = {scalar},\
-                     >"
+                    "{runtime_path}::texture::Texture{multi_string}{dim_string}{array_string}<\
+                        &'g dyn {runtime_path}::texture::Read<\
+                            Coordinates = {runtime_path}::{vec}<i32>, \
+                            Component = {scalar}\
+                        >\
+                    >",
+                    multi_string = if multisampled { "Multisampled" } else { "" },
+                    array_string = if arrayed { "Array" } else { "" },
                 )
             }
             Type::Sampler => write!(out, "{runtime_path}::Sampler"),
@@ -745,11 +765,11 @@ impl fmt::Display for RtItem {
                 VectorSize::Tri => "Vec3::splat_from_scalar",
                 VectorSize::Quad => "Vec4::splat_from_scalar",
             },
-            RtItem::TextureLoad => "Texture::load",
-            RtItem::TextureDimensions => "Texture::dimensions",
-            RtItem::TextureNumLevels => "Texture::mip_levels",
-            RtItem::TextureNumLayers => "Texture::array_layers",
-            RtItem::TextureNumSamples => "Texture::samples",
+            RtItem::TextureLoad => "texture::Read::read_texel",
+            RtItem::TextureDimensions => "texture::dimensions",
+            RtItem::TextureNumLevels => "texture::Query::mip_levels",
+            RtItem::TextureNumLayers => "texture::Query::array_layers",
+            RtItem::TextureNumSamples => "texture::Query::samples",
             RtItem::DiscardFn => "discard",
             RtItem::ZeroFn => "zero",
         })

--- a/back/src/writer.rs
+++ b/back/src/writer.rs
@@ -49,6 +49,10 @@ enum Indirection {
     /// The Rust expression is not necessarily a mutable place; it may be borrowed
     /// immutably but not mutably.
     Ordinary,
+
+    /// The Naga expression has a value type, but the Rust expression is a reference type.
+    /// This is currently used only for texture (image) handles.
+    Ref,
 }
 
 /// Modifier for how scalars in Naga types are translated to Rust based on context.
@@ -1153,17 +1157,29 @@ impl Writer {
         Ok(match (requested, plain) {
             // The plain form expression will be a place.
             // Convert it to a reference to match the Naga pointer type.
+            //
+            // Or, the plain form expression will be a Rust value that we want to take by
+            // reference (currently, a texture handle; in the future, buffers too).
+            //
             // TODO: We need to choose which borrow operator to use.
-            (Indirection::Ordinary, Indirection::Place) => {
+            (Indirection::Ordinary, Indirection::Place)
+            | (Indirection::Ref, Indirection::Ordinary) => {
                 ra::Expr::Borrow(ra::PtrKind::Shared(None), Box::new(plain_expr))
             }
 
             // The plain form expression will be a pointer, but the caller wants its pointee.
             // Insert a dereference operator.
-            (Indirection::Place, Indirection::Ordinary) => ra::Expr::Deref(Box::new(plain_expr)),
+            (Indirection::Place, Indirection::Ordinary)
+            | (Indirection::Ordinary, Indirection::Ref) => ra::Expr::Deref(Box::new(plain_expr)),
+
             // Matches.
             (Indirection::Place, Indirection::Place)
-            | (Indirection::Ordinary, Indirection::Ordinary) => plain_expr,
+            | (Indirection::Ordinary, Indirection::Ordinary)
+            | (Indirection::Ref, Indirection::Ref) => plain_expr,
+
+            (Indirection::Ref, Indirection::Place) | (Indirection::Place, Indirection::Ref) => {
+                unreachable!("multi-level ref/deref")
+            }
         })
     }
 
@@ -1377,7 +1393,8 @@ impl Writer {
                 self.unimplemented_expr("texture sampling (other than textureLoad)")?
             }
             Expression::ImageQuery { image, query } => {
-                let image_expr = self.translate_expr(image, expr_ctx)?;
+                let image_expr =
+                    self.expr_ast_with_indirection(image, expr_ctx, Indirection::Ref)?;
                 match query {
                     naga::ImageQuery::Size { level } => ra::Expr::call_rt(
                         ra::RtItem::TextureDimensions,
@@ -1413,7 +1430,7 @@ impl Writer {
             } => ra::Expr::call_rt(
                 ra::RtItem::TextureLoad,
                 [
-                    self.translate_expr(image, expr_ctx)?,
+                    self.expr_ast_with_indirection(image, expr_ctx, Indirection::Ref)?,
                     self.translate_expr(coordinate, expr_ctx)?,
                     if let Some(array_index) = array_index {
                         ra::Expr::call_rt(
@@ -1724,28 +1741,26 @@ impl Writer {
             TypeInner::Sampler { comparison: true } => ra::Type::SamplerComparison,
             TypeInner::Image {
                 dim,
-                arrayed: _, // TODO: support array textures
-                class,      // TODO: might want separate traits per class
+                arrayed,
+                class,
             } => {
-                // TODO: we will want to support statically dispatched texture access,
-                // but that will require more generics work on the resource struct.
-                // `dyn` is a placeholder for further work.
-                let scalar_type: ra::Scalar = match class {
-                    naga::ImageClass::Sampled { kind, multi: _ } => match kind {
-                        naga::ScalarKind::Sint => ra::Scalar::I32,
-                        naga::ScalarKind::Uint => ra::Scalar::U32,
-                        naga::ScalarKind::Float => ra::Scalar::F32,
-                        naga::ScalarKind::Bool => ra::Scalar::Bool,
-                        naga::ScalarKind::AbstractInt | naga::ScalarKind::AbstractFloat => {
-                            unreachable!(
-                                "abstract types should not appear in IR presented to backends"
-                            )
-                        }
-                    },
-                    naga::ImageClass::Depth { multi: _ } => ra::Scalar::F32,
-                    naga::ImageClass::External => {
-                        return Err(Error::Unimplemented("external texture types".into()));
-                    }
+                let (scalar_type, multisampled): (ra::Scalar, bool) = match class {
+                    naga::ImageClass::Sampled { kind, multi } => (
+                        match kind {
+                            naga::ScalarKind::Sint => ra::Scalar::I32,
+                            naga::ScalarKind::Uint => ra::Scalar::U32,
+                            naga::ScalarKind::Float => ra::Scalar::F32,
+                            naga::ScalarKind::Bool => ra::Scalar::Bool,
+                            naga::ScalarKind::AbstractInt | naga::ScalarKind::AbstractFloat => {
+                                unreachable!(
+                                    "abstract types should not appear in IR presented to backends"
+                                )
+                            }
+                        },
+                        multi,
+                    ),
+                    naga::ImageClass::Depth { multi } => (ra::Scalar::F32, multi),
+                    naga::ImageClass::External => (ra::Scalar::F32, false),
                     naga::ImageClass::Storage { .. } => {
                         return Err(Error::Unimplemented("storage texture types".into()));
                     }
@@ -1753,6 +1768,8 @@ impl Writer {
                 ra::Type::Texture {
                     dim,
                     scalar: scalar_type,
+                    multisampled,
+                    arrayed,
                 }
             }
             TypeInner::Atomic(scalar) => ra::Type::Atomic(scalar.try_into()?),

--- a/back/tests/textual.rs
+++ b/back/tests/textual.rs
@@ -198,7 +198,7 @@ fn globals_and_resources_enabled_and_visibility() {
                 #[doc = \"group(0) binding(0)\"]
                 foo: ::naga_rust_rt::Scalar<i32>,
                 #[doc = \"group(0) binding(1)\"]
-                texture: &'g dyn ::naga_rust_rt::Texture<Dimensions = ::naga_rust_rt::Vec2<u32>,Coordinates = ::naga_rust_rt::Vec2<i32>,Scalar = f32,>,
+                texture: ::naga_rust_rt::texture::Texture2d<&'g dyn ::naga_rust_rt::texture::Read<Coordinates = ::naga_rust_rt::Vec2<i32>, Component = f32>>,
             }
             struct Globals<'g> {
                 resources: &'g Resources<'g>,
@@ -247,7 +247,7 @@ fn globals_and_resources_enabled_and_visibility() {
                 #[doc = \"group(0) binding(0)\"]
                 pub foo: ::naga_rust_rt::Scalar<i32>,
                 #[doc = \"group(0) binding(1)\"]
-                pub texture: &'g dyn ::naga_rust_rt::Texture<Dimensions = ::naga_rust_rt::Vec2<u32>,Coordinates = ::naga_rust_rt::Vec2<i32>,Scalar = f32,>,
+                pub texture: ::naga_rust_rt::texture::Texture2d<&'g dyn ::naga_rust_rt::texture::Read<Coordinates = ::naga_rust_rt::Vec2<i32>, Component = f32>>,
             }
             struct Globals<'g> {
                 pub resources: &'g Resources<'g>,

--- a/embed/CHANGELOG.md
+++ b/embed/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 * Support for matrices.
+* Support for texture loads (but not yet filtering).
 * Support for `continuing` and `break if` control flow.
 * Support for boolean vector functions `any()`, `all()`, and `select()`.
 * Partial support for additional math functions, such as `cross()` and `smoothstep()`.

--- a/embed/tests/interop/textures.rs
+++ b/embed/tests/interop/textures.rs
@@ -1,47 +1,86 @@
+use core::cell::RefCell;
+use core::marker::PhantomData;
 use core::num::NonZeroU32;
 
-use naga_rust_embed::rt::{self, Vec2, Vec4};
+use naga_rust_embed::rt::{self, Scalar, Vec2, Vec3, Vec4, texture::ONE};
 use naga_rust_embed::wgsl;
 
-#[test]
-fn texture_query_and_load() {
-    struct MyTexture;
-    impl rt::Texture for MyTexture {
-        type Dimensions = Vec2<u32>;
-        type Coordinates = Vec2<i32>;
-        type Scalar = f32;
+// -------------------------------------------------------------------------------------------------
 
-        fn dimensions(&self, _mip_level: i32) -> Self::Dimensions {
-            Vec2::new(100, 100)
-        }
-
-        fn array_layers(&self) -> NonZeroU32 {
-            NonZeroU32::MIN
-        }
-
-        fn mip_levels(&self) -> NonZeroU32 {
-            NonZeroU32::MIN
-        }
-
-        fn samples(&self) -> NonZeroU32 {
-            NonZeroU32::MIN
-        }
-
-        fn load(
-            &self,
-            coordinates: Self::Coordinates,
-            _array_layer: i32,
-            _sample: i32,
-            mip_level: i32,
-        ) -> Vec4<f32> {
-            assert_eq!(coordinates, Vec2::new(10, 20));
-            assert_eq!(mip_level, 0);
-            Vec4::new(1.0, 2.0, 3.0, 4.0)
+struct MockTextureStorage<C, F: ?Sized> {
+    _phantom: PhantomData<fn(C)>,
+    function: RefCell<F>,
+}
+impl<C, F> MockTextureStorage<C, F>
+where
+    C: Copy + 'static,
+    F: FnMut(C, i32, i32, i32) -> Vec4<f32>,
+{
+    fn new(function: F) -> Self {
+        Self {
+            _phantom: PhantomData,
+            function: RefCell::new(function),
         }
     }
+}
+impl<C, F> rt::texture::Read for MockTextureStorage<C, F>
+where
+    C: Copy + 'static,
+    F: FnMut(C, i32, i32, i32) -> Vec4<f32>,
+{
+    type Coordinates = C;
+    type Component = f32;
 
-    // TODO: for full coverage, we need many different texture binding types and their corresponding
-    // call overloads.
+    fn read_texel(
+        &self,
+        coordinates: Self::Coordinates,
+        array_layer: i32,
+        sample: i32,
+        mip_level: i32,
+    ) -> Vec4<f32> {
+        (self.function.borrow_mut())(coordinates, array_layer, sample, mip_level)
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+#[test]
+fn query_and_load_1d() {
+    wgsl!(
+        resource_struct = Resources,
+        r"
+        @group(0) @binding(0) var my_texture: texture_1d<f32>;
+        fn dimensions() -> u32 {
+            return textureDimensions(my_texture, 0);
+        }
+        fn load(position: i32) -> vec4f {
+            return textureLoad(my_texture, position, 0);
+        }"
+    );
+
+    let mut call_count = 0;
+
+    let ts = MockTextureStorage::new(|coordinates, _a, _s, mip_level| {
+        assert_eq!(coordinates, Scalar::new(10));
+        assert_eq!(mip_level, 0);
+        call_count += 1;
+        Vec4::new(1.0, 2.0, 3.0, 4.0)
+    });
+
+    let res = Resources {
+        my_texture: rt::Texture1d {
+            dimensions: Scalar::new(NonZeroU32::new(100).unwrap()),
+            mip_levels: NonZeroU32::new(1).unwrap(),
+            data: &ts,
+        },
+    };
+    assert_eq!(res.dimensions(), 100);
+    assert_eq!(res.load(Scalar::new(10)), Vec4::new(1.0, 2.0, 3.0, 4.0));
+    assert_eq!(call_count, 1);
+}
+
+#[test]
+fn query_and_load_2d() {
     wgsl!(
         resource_struct = Resources,
         r"
@@ -54,12 +93,154 @@ fn texture_query_and_load() {
         }"
     );
 
+    let mut call_count = 0;
+
+    let ts = MockTextureStorage::new(|coordinates, _a, _s, mip_level| {
+        assert_eq!(coordinates, Vec2::new(10, 20));
+        assert_eq!(mip_level, 0);
+        call_count += 1;
+        Vec4::new(1.0, 2.0, 3.0, 4.0)
+    });
+
     let res = Resources {
-        my_texture: &MyTexture,
+        my_texture: rt::Texture2d {
+            dimensions: Vec2::splat(NonZeroU32::new(100).unwrap()),
+            mip_levels: NonZeroU32::new(1).unwrap(),
+            data: &ts,
+        },
     };
     assert_eq!(res.dimensions(), Vec2::new(100u32, 100));
     assert_eq!(res.load(Vec2::new(10, 20)), Vec4::new(1.0, 2.0, 3.0, 4.0));
+    assert_eq!(call_count, 1);
 }
+
+#[test]
+fn query_and_load_3d() {
+    wgsl!(
+        resource_struct = Resources,
+        r"
+        @group(0) @binding(0) var my_texture: texture_3d<f32>;
+        fn dimensions() -> vec3u {
+            return textureDimensions(my_texture, 0);
+        }
+        fn load(position: vec3i) -> vec4f {
+            return textureLoad(my_texture, position, 0);
+        }"
+    );
+
+    let mut call_count = 0;
+
+    let ts = MockTextureStorage::new(|coordinates, _a, _s, mip_level| {
+        assert_eq!(coordinates, Vec3::new(10, 20, 30));
+        assert_eq!(mip_level, 0);
+        call_count += 1;
+        Vec4::new(1.0, 2.0, 3.0, 4.0)
+    });
+
+    let res = Resources {
+        my_texture: rt::Texture3d {
+            dimensions: Vec3::splat(NonZeroU32::new(100).unwrap()),
+            mip_levels: NonZeroU32::new(1).unwrap(),
+            data: &ts,
+        },
+    };
+    assert_eq!(res.dimensions(), Vec3::new(100u32, 100, 100));
+    assert_eq!(
+        res.load(Vec3::new(10, 20, 30)),
+        Vec4::new(1.0, 2.0, 3.0, 4.0)
+    );
+    assert_eq!(call_count, 1);
+}
+
+// TODO: test all texture types
+
+// -------------------------------------------------------------------------------------------------
+
+#[test]
+fn mip_level_dimensions() {
+    wgsl!(
+        resource_struct = Resources,
+        r"
+        @group(0) @binding(0) var texture1d: texture_1d<f32>;
+        @group(0) @binding(0) var texture2d: texture_2d<f32>;
+        @group(0) @binding(0) var texture3d: texture_3d<f32>;
+        struct Output {
+            one: u32,
+            two: vec2u,
+            three: vec3u,
+        }
+        fn dimensions(mip_level: i32) -> Output {
+            return Output(
+                textureDimensions(texture1d, mip_level),
+                textureDimensions(texture2d, mip_level),
+                textureDimensions(texture3d, mip_level),
+            );
+        }
+        "
+    );
+
+    let res = Resources {
+        texture1d: rt::Texture1d {
+            dimensions: Scalar::new(NonZeroU32::new(15).unwrap()),
+            mip_levels: NonZeroU32::new(1).unwrap(),
+            data: &rt::texture::Constant::new(Vec4::splat(0.0)),
+        },
+        texture2d: rt::Texture2d {
+            dimensions: Vec2::new(ONE, NonZeroU32::new(15).unwrap()),
+            mip_levels: NonZeroU32::new(1).unwrap(),
+            data: &rt::texture::Constant::new(Vec4::splat(0.0)),
+        },
+        texture3d: rt::Texture3d {
+            dimensions: Vec3::new(
+                ONE,
+                NonZeroU32::new(15).unwrap(),
+                NonZeroU32::new(16).unwrap(),
+            ),
+            mip_levels: NonZeroU32::new(1).unwrap(),
+            data: &rt::texture::Constant::new(Vec4::splat(0.0)),
+        },
+    };
+    pretty_assertions::assert_eq!(
+        [
+            res.dimensions(0),
+            res.dimensions(1),
+            res.dimensions(2),
+            res.dimensions(3),
+            res.dimensions(4),
+        ],
+        [
+            Output {
+                one: 15,
+                two: Vec2::new(1, 15),
+                three: Vec3::new(1, 15, 16),
+            },
+            Output {
+                one: 7,
+                two: Vec2::new(1, 7),
+                three: Vec3::new(1, 7, 8),
+            },
+            Output {
+                one: 3,
+                two: Vec2::new(1, 3),
+                three: Vec3::new(1, 3, 4),
+            },
+            Output {
+                one: 1,
+                two: Vec2::new(1, 1),
+                three: Vec3::new(1, 1, 2),
+            },
+            // out of range for all but the 3D example; indeterminate per spec
+            // <<https://www.w3.org/TR/2026/CRD-WGSL-20260507/#texturedimensions>
+            Output {
+                one: 1,
+                two: Vec2::new(1, 1),
+                three: Vec3::new(1, 1, 1),
+            },
+        ]
+    );
+}
+
+// -------------------------------------------------------------------------------------------------
 
 /// We don’t implement texture sampling yet, but shaders that mentions samplers should still be
 /// compilable.

--- a/rt/CHANGELOG.md
+++ b/rt/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 * Matrix types.
-* `Texture` trait and `Sampler` struct for providing textures to shaders.
+* `texture` module with `Texture` and `Sampler` structs, for providing textures to shaders.
 * Many miscellaneous methods and trait implementations.
 
 ## 0.1.0 (2025-03-25)

--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -22,6 +22,8 @@ doctest = false
 
 [features]
 default = []
+# If enabled, implement texture access traits for `Box`, `Rc`, and `Arc`
+alloc = []
 # If enabled, use `std`’s math functions instead of `libm`’s
 std = []
 

--- a/rt/src/lib.rs
+++ b/rt/src/lib.rs
@@ -10,17 +10,22 @@
 
 #![no_std]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
 mod matrix;
-mod texture;
+pub mod texture;
 mod vector;
 
 // -------------------------------------------------------------------------------------------------
 
 pub use matrix::*;
-pub use texture::*;
+pub use texture::{
+    Sampler, Texture1d, Texture2d, Texture2dArray, Texture3d, TextureCube, TextureCubeArray,
+    TextureMultisampled2d,
+};
 pub use vector::*;
 
 // Traits the generated code refers to

--- a/rt/src/texture.rs
+++ b/rt/src/texture.rs
@@ -1,119 +1,413 @@
 use core::marker::PhantomData;
 use core::num::NonZeroU32;
 
-use crate::{Vec2, Vec3, Vec4};
+use crate::{Scalar, Vec2, Vec3, Vec4};
+
+// -------------------------------------------------------------------------------------------------
 
 /// Texture sampler (placeholder).
 ///
 /// Use this type to satisfy a sampler binding in a resource struct.
 pub struct Sampler;
 
-// TODO: Consider, instead of putting all the metadata as methods on the Txture trait,
-// defining a struct with the metadata. This ensures consistency (particularly for things like
-// per-mip-level dimensions) and avoids ever using dynamic dispatch, at the price of possibly
-// duplicating some integers.
+/// The number 1, as a [`NonZeroU32`].
+///
+/// Convenience alias because textures heavily use non-zero sizes.
+pub const ONE: NonZeroU32 = NonZeroU32::MIN;
 
-/// Implement this trait to provide a texture to the shader code.
-// TODO: This will need expansion to handle depth textures
-pub trait Texture {
-    /// Type of the dimensions of the texture.
-    /// Should be a [`Scalar`][crate::Scalar], [`Vec2`][crate::Vec2], or [`Vec3`][crate::Vec3]
-    /// of `u32`.
-    type Dimensions: Copy + 'static;
+// -------------------------------------------------------------------------------------------------
 
-    /// Type of a point within the texture.
-    /// Should be a [`Scalar`][crate::Scalar], [`Vec2`][crate::Vec2], or [`Vec3`][crate::Vec3]
-    /// of `i32`.
+/// 1-dimensional texture object.
+///
+/// Use this type to satisfy a texture binding in a resource struct,
+/// when the binding has WGSL type `texture_1d`.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct Texture1d<T: ?Sized> {
+    pub dimensions: Scalar<NonZeroU32>,
+    pub mip_levels: NonZeroU32,
+    pub data: T,
+}
+
+/// 2-dimensional texture object.
+///
+/// Use this type to satisfy a texture binding in a resource struct,
+/// when the binding has WGSL type `texture_2d` or `texture_external`.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct Texture2d<T: ?Sized> {
+    pub dimensions: Vec2<NonZeroU32>,
+    pub mip_levels: NonZeroU32,
+    pub data: T,
+}
+
+/// 2-dimensional array texture object.
+///
+/// Use this type to satisfy a texture binding in a resource struct,
+/// when the binding has WGSL type `texture_2d_array`.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct Texture2dArray<T: ?Sized> {
+    pub dimensions: Vec2<NonZeroU32>,
+    pub array_layers: NonZeroU32,
+    pub mip_levels: NonZeroU32,
+    pub data: T,
+}
+
+/// 3-dimensional texture object.
+///
+/// Use this type to satisfy a texture binding in a resource struct,
+/// when the binding has WGSL type `texture_3d`.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct Texture3d<T: ?Sized> {
+    pub dimensions: Vec3<NonZeroU32>,
+    pub mip_levels: NonZeroU32,
+    pub data: T,
+}
+
+/// Cubemap texture object.
+///
+/// Use this type to satisfy a texture binding in a resource struct,
+/// when the binding has WGSL type `texture_cube`.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct TextureCube<T: ?Sized> {
+    pub dimensions: Vec2<NonZeroU32>,
+    pub mip_levels: NonZeroU32,
+    pub data: T,
+}
+
+/// Cubemap array texture object.
+///
+/// Use this type to satisfy a texture binding in a resource struct,
+/// when the binding has WGSL type `texture_cube_array`.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct TextureCubeArray<T: ?Sized> {
+    pub dimensions: Vec2<NonZeroU32>,
+    pub array_layers: NonZeroU32,
+    pub mip_levels: NonZeroU32,
+    pub data: T,
+}
+
+/// Multisampled texture object.
+///
+/// Use this type to satisfy a texture binding in a resource struct,
+/// when the binding has WGSL type `texture_multisampled_2d`.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct TextureMultisampled2d<T: ?Sized> {
+    pub dimensions: Vec2<NonZeroU32>,
+    pub samples: NonZeroU32,
+    pub data: T,
+}
+
+// -------------------------------------------------------------------------------------------------
+
+// TODO: we want to have these convenient constructors but without a requirement for borrowing.
+// We could solve that by using `Box` instead of `&`, but it would be better to work on a general
+// mechanism to avoid `dyn`.
+
+impl<'d, C: Component> Texture1d<&'d dyn Read<Coordinates = Scalar<i32>, Component = C>> {
+    pub fn one_texel(texel: &'d Constant<Scalar<i32>, C>) -> Self {
+        Self {
+            dimensions: Scalar::new(ONE),
+            mip_levels: ONE,
+            data: texel,
+        }
+    }
+}
+
+impl<'d, C: Component> Texture2d<&'d dyn Read<Coordinates = Vec2<i32>, Component = C>> {
+    pub fn one_texel(texel: &'d Constant<Vec2<i32>, C>) -> Self {
+        Self {
+            dimensions: Vec2::splat(ONE),
+            mip_levels: ONE,
+            data: texel,
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+/// Reads one texel from a texture.
+///
+/// Implement this trait and then put the implementation in a [`Texture1d`], [`Texture2d`], etc.
+/// to provide a texture to your shader code.
+//
+// TODO: Usage example.
+pub trait Read {
     type Coordinates: Copy + 'static;
-
-    /// Numeric type exposed to the shader.
-    ///
-    /// Should be one of [`u32`], [`i32`], or [`f32`], and must match the parameter of the
-    /// texture type in the shader.
-    type Scalar;
-
-    /// Returns the dimensions of the texture.
-    fn dimensions(&self, mip_level: i32) -> Self::Dimensions;
-
-    /// Returns the count of array layers of the texture.
-    fn array_layers(&self) -> NonZeroU32;
-
-    /// Returns the count of mip levels of the texture.
-    fn mip_levels(&self) -> NonZeroU32;
-
-    /// Returns the count of samples of the texture.
-    fn samples(&self) -> NonZeroU32;
+    type Component: Component;
 
     /// Loads a single texel from the texture.
     ///
-    /// If the coordinates are out of bounds, do not panic, but perform one of the behaviors
-    /// specified in <https://www.w3.org/TR/WGSL/#textureload>.
-    fn load(
+    /// If the coordinates are out of bounds, the implementation should not panic,
+    /// but perform one of the behaviors specified in <https://www.w3.org/TR/WGSL/#textureload>.
+    fn read_texel(
         &self,
         coordinates: Self::Coordinates,
         array_layer: i32,
         sample: i32,
         mip_level: i32,
-    ) -> Vec4<Self::Scalar>;
+    ) -> Vec4<Self::Component>;
 }
 
-/// A [`Texture`] whose texels all have a single value.
-pub struct ConstantTexture<D: Copy + 'static, C: Copy + 'static, S> {
-    pub dimensions: D,
-    pub coordinates: PhantomData<fn(C)>,
-    pub texel: Vec4<S>,
-}
+/// Information about a texture.
+///
+/// This trait is implemented by all the texture types like [`Texture1d`], [`Texture2d`], etc.
+pub trait Query {
+    /// Type of the dimensions of the texture.
+    /// Should be a [`Scalar`], [`Vec2`], or [`Vec3`] of [`NonZeroU32`].
+    type Dimensions: Dimensions;
 
-impl<S: Copy> ConstantTexture<Vec2<u32>, Vec2<i32>, S> {
-    pub const fn new_2d(dimensions: Vec2<u32>, texel: Vec4<S>) -> Self {
-        Self {
-            dimensions,
-            coordinates: PhantomData,
-            texel,
-        }
-    }
-}
+    /// Numeric type exposed to the shader.
+    ///
+    /// Should be one of [`u32`], [`i32`], or [`f32`], and must match the parameter of the
+    /// texture type in the shader.
+    type Component: Component;
 
-impl<S: Copy> ConstantTexture<Vec3<u32>, Vec3<i32>, S> {
-    pub const fn new_3d(dimensions: Vec3<u32>, texel: Vec4<S>) -> Self {
-        Self {
-            dimensions,
-            coordinates: PhantomData,
-            texel,
-        }
-    }
-}
+    /// Returns the dimensions of mip level 0 of the texture.
+    fn base_dimensions(&self) -> Self::Dimensions;
 
-impl<D: Copy + 'static, C: Copy + 'static, S: Copy> Texture for ConstantTexture<D, C, S> {
-    type Dimensions = D;
-
-    type Coordinates = C;
-
-    type Scalar = S;
-
-    fn dimensions(&self, _mip_level: i32) -> Self::Dimensions {
-        self.dimensions
-    }
-
+    /// Returns the count of array layers of the texture.
+    ///
+    /// For non-array textures, returns 1.
     fn array_layers(&self) -> NonZeroU32 {
-        NonZeroU32::MIN
+        ONE
     }
 
+    /// Returns the count of mip levels of the texture.
     fn mip_levels(&self) -> NonZeroU32 {
-        NonZeroU32::MIN
+        ONE
     }
 
+    /// Returns the count of samples of the texture.
+    ///
+    /// For non-multisampled textures, returns 1.
     fn samples(&self) -> NonZeroU32 {
-        NonZeroU32::MIN
+        ONE
     }
+}
 
-    fn load(
+/// Types which can be components of texels.
+pub trait Component: Copy + 'static {}
+impl Component for u32 {}
+impl Component for i32 {}
+impl Component for f32 {}
+
+// -------------------------------------------------------------------------------------------------
+
+macro_rules! impl_read_forwarder_struct {
+    ($texture_type:ident) => {
+        impl<T: ?Sized + Read> Read for $texture_type<T> {
+            type Coordinates = T::Coordinates;
+            type Component = T::Component;
+
+            fn read_texel(
+                &self,
+                coordinates: Self::Coordinates,
+                array_layer: i32,
+                sample: i32,
+                mip_level: i32,
+            ) -> Vec4<Self::Component> {
+                self.data
+                    .read_texel(coordinates, array_layer, sample, mip_level)
+            }
+        }
+    };
+}
+
+impl_read_forwarder_struct!(Texture1d);
+impl_read_forwarder_struct!(Texture2d);
+impl_read_forwarder_struct!(Texture2dArray);
+impl_read_forwarder_struct!(Texture3d);
+impl_read_forwarder_struct!(TextureCube);
+impl_read_forwarder_struct!(TextureCubeArray);
+impl_read_forwarder_struct!(TextureMultisampled2d);
+
+macro_rules! impl_read_forwarder_deref {
+    ($($ty:tt)*) => {
+        impl<T: ?Sized + Read> Read for $($ty)* {
+            type Coordinates = T::Coordinates;
+            type Component = T::Component;
+
+            fn read_texel(
+                &self,
+                coordinates: Self::Coordinates,
+                array_layer: i32,
+                sample: i32,
+                mip_level: i32,
+            ) -> Vec4<Self::Component> {
+                T::read_texel(&**self, coordinates, array_layer, sample, mip_level)
+            }
+        }
+    };
+}
+
+impl_read_forwarder_deref!(&T);
+impl_read_forwarder_deref!(&mut T);
+#[cfg(feature = "alloc")]
+impl_read_forwarder_deref!(alloc::boxed::Box<T>);
+#[cfg(feature = "alloc")]
+impl_read_forwarder_deref!(alloc::rc::Rc<T>);
+#[cfg(feature = "alloc")]
+impl_read_forwarder_deref!(alloc::sync::Arc<T>);
+
+// -------------------------------------------------------------------------------------------------
+
+macro_rules! query_common {
+    () => {
+        type Component = T::Component;
+        fn base_dimensions(&self) -> Self::Dimensions {
+            self.dimensions
+        }
+    };
+}
+
+macro_rules! query_mip {
+    () => {
+        fn mip_levels(&self) -> NonZeroU32 {
+            self.mip_levels
+        }
+    };
+}
+
+impl<T: ?Sized + Read> Query for Texture1d<T> {
+    type Dimensions = Scalar<NonZeroU32>;
+    query_common!();
+    query_mip!();
+}
+
+impl<T: ?Sized + Read> Query for Texture2d<T> {
+    type Dimensions = Vec2<NonZeroU32>;
+    query_common!();
+    query_mip!();
+}
+
+impl<T: ?Sized + Read> Query for Texture2dArray<T> {
+    type Dimensions = Vec2<NonZeroU32>;
+    query_common!();
+    query_mip!();
+    fn array_layers(&self) -> NonZeroU32 {
+        self.array_layers
+    }
+}
+
+impl<T: ?Sized + Read> Query for Texture3d<T> {
+    type Dimensions = Vec3<NonZeroU32>;
+    query_common!();
+    query_mip!();
+}
+
+impl<T: ?Sized + Read> Query for TextureCube<T> {
+    type Dimensions = Vec2<NonZeroU32>;
+    query_common!();
+    query_mip!();
+}
+
+impl<T: ?Sized + Read> Query for TextureCubeArray<T> {
+    type Dimensions = Vec2<NonZeroU32>;
+    query_common!();
+    query_mip!();
+    fn array_layers(&self) -> NonZeroU32 {
+        self.array_layers
+    }
+}
+
+impl<T: ?Sized + Read> Query for TextureMultisampled2d<T> {
+    type Dimensions = Vec2<NonZeroU32>;
+    query_common!();
+    fn samples(&self) -> NonZeroU32 {
+        self.samples
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+/// Generic texture data container for textures whose texels are all identical.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)] // TODO: derives have bounds on C
+pub struct Constant<C, T> {
+    pub texel: Vec4<T>,
+    _phantom: PhantomData<fn(C)>,
+}
+
+impl<C: Copy + 'static, T: Component> Constant<C, T> {
+    pub const fn new(texel: Vec4<T>) -> Self {
+        Self {
+            texel,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<C: Copy + 'static, T: Component> Read for Constant<C, T> {
+    type Coordinates = C;
+    type Component = T;
+
+    fn read_texel(
         &self,
         _coordinates: Self::Coordinates,
         _array_layer: i32,
         _sample: i32,
         _mip_level: i32,
-    ) -> Vec4<Self::Scalar> {
+    ) -> Vec4<Self::Component> {
         self.texel
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+/// Computes the dimensions of a specific mip level of a texture.
+///
+/// The result is meaningless if the mip level is out of bounds.
+//
+// Design note: The result is `u32`, not `NonZeroU32`, for the sake of the shader code which does
+// not have `NonZero` types.
+pub fn dimensions<Q>(texture: &Q, mip_level: i32) -> <Q::Dimensions as Dimensions>::Plain
+where
+    Q: ?Sized + Query,
+{
+    Dimensions::at_mip_level(texture.base_dimensions(), mip_level as u32)
+}
+
+use dim::Dimensions;
+mod dim {
+    use super::*;
+
+    /// Semi-private trait implemented for vectors that can describe texture dimensions.
+    /// Helper for [`dimensions()`].
+    pub trait Dimensions: Copy + 'static {
+        /// The vector with `u32` components instead of `NonZeroU32`.
+        type Plain;
+
+        fn at_mip_level(self, mip_level: u32) -> Self::Plain;
+    }
+
+    impl Dimensions for Scalar<NonZeroU32> {
+        type Plain = Scalar<u32>;
+        fn at_mip_level(self, mip_level: u32) -> Self::Plain {
+            Scalar::new(mip_divide_size(self.0, mip_level))
+        }
+    }
+    impl Dimensions for Vec2<NonZeroU32> {
+        type Plain = Vec2<u32>;
+        fn at_mip_level(self, mip_level: u32) -> Self::Plain {
+            Vec2::new(
+                mip_divide_size(self.x, mip_level),
+                mip_divide_size(self.y, mip_level),
+            )
+        }
+    }
+    impl Dimensions for Vec3<NonZeroU32> {
+        type Plain = Vec3<u32>;
+        fn at_mip_level(self, mip_level: u32) -> Self::Plain {
+            Vec3::new(
+                mip_divide_size(self.x, mip_level),
+                mip_divide_size(self.y, mip_level),
+                mip_divide_size(self.z, mip_level),
+            )
+        }
+    }
+
+    /// Computes one component of the size of a given mip level of a texture,
+    /// given the size at level 0.
+    fn mip_divide_size(size: NonZeroU32, mip_level: u32) -> u32 {
+        // Per <https://www.w3.org/TR/2026/CRD-webgpu-20260507/#abstract-opdef-logical-miplevel-specific-texture-extent>
+        (size.get() >> mip_level).max(1)
     }
 }


### PR DESCRIPTION
This is a lot more boilerplate for us, but it has advantages:

* Users no longer have to implement all the getters/queries, and therefore can’t do it in an inconsistent or overly expensive way.
* Frees users of the obligation to pass us a reference to a texture object; now they only need to pass a reference to the texture data storage, which is a lot more likely to already exist in some form. (We should still get rid of the reference entirely somehow.)