### PR TITLE
Fix accidental loss of versioned doc link.

### DIFF
--- a/examples/render/src/main.rs
+++ b/examples/render/src/main.rs
@@ -181,7 +181,7 @@ impl Active {
             &self.device,
             &wgpu::SurfaceConfiguration {
                 usage: wgpu::TextureUsages::COPY_DST,
-                // guaranteed to work per https://docs.rs/wgpu/latest/wgpu/type.SurfaceConfiguration.html#structfield.format
+                // guaranteed to work per https://docs.rs/wgpu/30.0.0/wgpu/type.SurfaceConfiguration.html#structfield.format
                 format: wgpu::TextureFormat::Bgra8Unorm,
                 color_space: wgpu::SurfaceColorSpace::Auto,
                 width: size.width,


### PR DESCRIPTION
I meant to update the version and pasted /latest/ instead.