### PR TITLE
Replace `syn` with `litrs`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,9 @@ name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "lock_api"
@@ -869,11 +872,11 @@ dependencies = [
 name = "naga-rust-macros"
 version = "0.2.0"
 dependencies = [
+ "litrs",
  "naga",
  "naga-rust-back",
  "proc-macro2",
  "quote",
- "syn",
 ]
 
 [[package]]

--- a/embed/CHANGELOG.md
+++ b/embed/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for `naga-rust-embed`
 
+## Unreleased
+
+### Changed
+
+* The macros’ parsing code has been rewritten.
+  It no longer depends on the `syn` library, and has more specific error messages in several cases.
+
 ## 0.2.0 (2026-05-14)
 
 ### Added

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -18,11 +18,13 @@ test = true # syntax error tests only
 doctest = false
 
 [dependencies]
+# We can get rid of this dependency if `Literal::str_value()` stabilizes.
+# <https://github.com/rust-lang/rust/issues/136652>
+litrs = { version = "1.0.0", features = ["proc-macro2"] }
 naga = { workspace = true, features = ["wgsl-in"] }
 naga-rust-back.workspace = true
 proc-macro2.workspace = true
 quote = "1.0.37"
-syn = { version = "2.0.100", default-features = false, features = ["parsing"] }
 
 [lints]
 workspace = true

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -10,13 +10,16 @@ use std::fmt;
 use std::fs;
 use std::path::PathBuf;
 
+use proc_macro2::TokenTree as TokenTree2;
 use quote::quote;
-use syn::Token;
 
 use naga_rust_back::Config;
 use naga_rust_back::naga;
 
 // -------------------------------------------------------------------------------------------------
+
+mod parsing;
+use parsing::{MacroError, Parser, unwrap_invisible_groups};
 
 #[cfg(test)]
 mod tests;
@@ -25,27 +28,31 @@ mod tests;
 
 #[proc_macro]
 pub fn include_wgsl_mr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let ConfigAndStr {
-        config,
-        string: path_literal,
-    } = syn::parse_macro_input!(input as ConfigAndStr);
-
-    match include_wgsl_mr_impl(config, &path_literal) {
-        Ok(expansion) => expansion.into(),
-        Err(error) => error.to_compile_error().into(),
+    match ConfigAndStr::parse(input.into()) {
+        Ok(ConfigAndStr {
+            config,
+            string_span: path_span,
+            string: path_literal,
+        }) => match include_wgsl_mr_impl(config, path_span, &path_literal) {
+            Ok(expansion) => expansion.into(),
+            Err(error) => error.to_compile_error(),
+        },
+        Err(e) => e.to_compile_error(),
     }
 }
 
 #[proc_macro]
 pub fn wgsl(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let ConfigAndStr {
-        config,
-        string: source_literal,
-    } = syn::parse_macro_input!(input as ConfigAndStr);
-
-    match parse_and_translate(config, source_literal.span(), &source_literal.value()) {
-        Ok(expansion) => expansion.into(),
-        Err(error) => error.to_compile_error().into(),
+    match ConfigAndStr::parse(input.into()) {
+        Ok(ConfigAndStr {
+            config,
+            string_span: source_span,
+            string: source_literal,
+        }) => match parse_and_translate(config, source_span, &source_literal) {
+            Ok(expansion) => expansion.into(),
+            Err(error) => error.to_compile_error(),
+        },
+        Err(e) => e.to_compile_error(),
     }
 }
 
@@ -62,62 +69,111 @@ pub fn dummy_attribute(
 
 /// Parsed syntax for the [`wgsl`] or [`include_wgsl_mr`] macros, which consist of configuration
 /// options `name = value_expr` followed by a string literal which is either source code or a path.
+#[derive(Debug)]
 struct ConfigAndStr {
     config: Config,
-    string: syn::LitStr,
+    string_span: proc_macro2::Span,
+    string: String,
 }
 
-impl syn::parse::Parse for ConfigAndStr {
-    fn parse(input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
+impl ConfigAndStr {
+    fn parse(input: proc_macro2::TokenStream) -> Result<Self, MacroError> {
+        const EXPECT_TOP_LEVEL: &str = "a string literal or configuration option";
         let mut config = macro_default_config();
+        let mut input = Parser::from_token_stream(input);
         loop {
-            // Try parsing the final string literal.
-            let not_a_string_error = match input.parse::<syn::LitStr>() {
-                Ok(string) => {
-                    // Accept a final optional comma after the string.
-                    if !input.is_empty() {
-                        input.parse::<Token![,]>()?;
-                    }
-                    return Ok(Self { config, string });
-                }
-                Err(e) => e,
-            };
+            match unwrap_invisible_groups(input.next_expect(EXPECT_TOP_LEVEL)?) {
+                // A literal must be the final string.
+                ref tt @ TokenTree2::Literal(ref literal_token) => {
+                    let quoted: String = literal_token.to_string();
+                    let unquoted: String = match litrs::StringLit::try_from(literal_token) {
+                        Ok(sl) => sl.into_value(),
+                        Err(e) => {
+                            return Err(if quoted.starts_with('"') {
+                                // It's probably a string literal but doesn’t parse.
+                                MacroError::new(literal_token.span(), e.to_string())
+                            } else {
+                                // It's probably a non-string literal.
+                                // Use our own error message so that we mention the possibility
+                                // of a configuration option.
+                                MacroError::unexpected_token(tt, EXPECT_TOP_LEVEL)
+                            });
+                        }
+                    };
 
-            let option_name = input.parse::<syn::Ident>().map_err(|mut e| {
-                e.combine(not_a_string_error);
-                e
-            })?;
-            input.parse::<Token![=]>()?;
-            match &*option_name.to_string() {
-                // The options parsed by this match should also be documented in
-                // `embed/src/configuration_syntax.md`.
-                "allow_unimplemented" => {
-                    config = config.allow_unimplemented(input.parse::<syn::LitBool>()?.value);
+                    // Accept a final optional comma after the string.
+                    match input.next() {
+                        Some(TokenTree2::Punct(punct)) if punct.as_char() == ',' => {}
+                        None => {}
+                        Some(other) => {
+                            return Err(MacroError::unexpected_token(&other, "comma or nothing"));
+                        }
+                    }
+
+                    return Ok(Self {
+                        config,
+                        string_span: literal_token.span(),
+                        string: unquoted,
+                    });
                 }
-                "explicit_types" => {
-                    config = config.explicit_types(input.parse::<syn::LitBool>()?.value);
+
+                // An identifier must be the name of a configuration option.
+                TokenTree2::Ident(option_name_ident) => {
+                    let option_name = option_name_ident.to_string();
+
+                    match input.next_expect("`=`")? {
+                        TokenTree2::Punct(punct) if punct.as_char() == '=' => {}
+                        other => {
+                            return Err(MacroError::unexpected_token(&other, "`=`"));
+                        }
+                    }
+
+                    match &*option_name {
+                        // The options parsed by this match should also be documented in
+                        // `embed/src/configuration_syntax.md`.
+                        "allow_unimplemented" => {
+                            config = config.allow_unimplemented(input.expect_bool()?);
+                        }
+                        "explicit_types" => {
+                            config = config.explicit_types(input.expect_bool()?);
+                        }
+                        "public_items" => {
+                            config = config.public_items(input.expect_bool()?);
+                        }
+                        // TODO: raw_pointers doesn’t actually work, and will need to be marked unsafe
+                        // when it is implemented. So, we don’t offer it yet.
+                        //
+                        // "raw_pointers" => {
+                        //     config = config.raw_pointers(input.expect_bool()?);
+                        // }
+                        "global_struct" => {
+                            config = config.global_struct(input.expect_ident()?);
+                        }
+                        "resource_struct" => {
+                            config = config.resource_struct(input.expect_ident()?);
+                        }
+                        _ => {
+                            return Err(MacroError::new(
+                                option_name_ident.span(),
+                                format!(
+                                    "`{option_name}` is not the name of a configuration option"
+                                ),
+                            ));
+                        }
+                    }
+
+                    match input.next_expect("comma")? {
+                        TokenTree2::Punct(punct) if punct.as_char() == ',' => {}
+                        other => {
+                            return Err(MacroError::unexpected_token(&other, "comma"));
+                        }
+                    }
                 }
-                "public_items" => {
-                    config = config.public_items(input.parse::<syn::LitBool>()?.value);
-                }
-                // TODO: raw_pointers doesn’t actually work, and will need to be marked unsafe
-                // when it is implemented. So, we don’t offer it yet.
-                //
-                // "raw_pointers" => {
-                //     config = config.raw_pointers(input.parse::<syn::LitBool>()?.value);
-                // }
-                "global_struct" => {
-                    config = config.global_struct(input.parse::<syn::Ident>()?.to_string());
-                }
-                "resource_struct" => {
-                    config = config.resource_struct(input.parse::<syn::Ident>()?.to_string());
-                }
-                _ => {
-                    let msg = format!("`{option_name}` is not the name of a configuration option");
-                    return Err(syn::Error::new_spanned(option_name, msg));
+
+                other => {
+                    return Err(MacroError::unexpected_token(&other, EXPECT_TOP_LEVEL));
                 }
             }
-            input.parse::<Token![,]>()?;
         }
     }
 }
@@ -134,20 +190,21 @@ fn macro_default_config() -> Config {
 
 fn include_wgsl_mr_impl(
     config: Config,
-    path_literal: &syn::LitStr,
-) -> Result<proc_macro2::TokenStream, syn::Error> {
+    path_span: proc_macro2::Span,
+    path_text: &str,
+) -> Result<proc_macro2::TokenStream, MacroError> {
     // We use manifest-relative paths because currently, there is no way to arrange for
     // source-file-relative paths.
     let mut absolute_path: PathBuf = PathBuf::from(
         std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set by Cargo"),
     );
-    absolute_path.push(path_literal.value());
+    absolute_path.push(path_text);
 
     // If this fails then we can't generate the `include_str!` we must generate.
     let absolute_path_str = absolute_path.to_str().ok_or_else(|| {
-        syn::Error::new_spanned(
-            path_literal,
-            format_args!(
+        MacroError::new(
+            path_span,
+            format!(
                 "absolute path “{p:?}” must be UTF-8",
                 p = absolute_path.display()
             ),
@@ -155,13 +212,13 @@ fn include_wgsl_mr_impl(
     })?;
 
     let wgsl_source_text: String = fs::read_to_string(&absolute_path).map_err(|error| {
-        syn::Error::new_spanned(
-            path_literal,
-            format_args!("failed to read “{absolute_path_str}”: {error}"),
+        MacroError::new(
+            path_span,
+            format!("failed to read “{absolute_path_str}”: {error}"),
         )
     })?;
 
-    let translated_tokens = parse_and_translate(config, path_literal.span(), &wgsl_source_text)?;
+    let translated_tokens = parse_and_translate(config, path_span, &wgsl_source_text)?;
 
     Ok(quote! {
         // Dummy include_str! call tells the compiler that we depend on this file,
@@ -176,11 +233,11 @@ fn parse_and_translate(
     config: Config,
     wgsl_source_span: proc_macro2::Span,
     wgsl_source_text: &str,
-) -> Result<proc_macro2::TokenStream, syn::Error> {
+) -> Result<proc_macro2::TokenStream, MacroError> {
     let module: naga::Module = naga::front::wgsl::parse_str(wgsl_source_text).map_err(|error| {
-        syn::Error::new(
+        MacroError::new(
             wgsl_source_span,
-            format_args!("failed to parse WGSL text: {}", ErrorChain(&error)),
+            format!("failed to parse WGSL text: {}", ErrorChain(&error)),
         )
     })?;
 
@@ -194,25 +251,25 @@ fn parse_and_translate(
     .subgroup_operations(naga::valid::SubgroupOperationSet::empty())
     .validate(&module)
     .map_err(|error| {
-        syn::Error::new(
+        MacroError::new(
             wgsl_source_span,
-            format_args!("failed to validate WGSL: {}", ErrorChain(&error)),
+            format!("failed to validate WGSL: {}", ErrorChain(&error)),
         )
     })?;
 
     let translated_source: String = naga_rust_back::write_string(&module, &module_info, config)
         .map_err(|error| {
-            syn::Error::new(
+            MacroError::new(
                 wgsl_source_span,
-                format_args!("failed to translate shader to Rust: {}", ErrorChain(&error)),
+                format!("failed to translate shader to Rust: {}", ErrorChain(&error)),
             )
         })?;
 
     let translated_tokens: proc_macro2::TokenStream =
         translated_source.parse().map_err(|error| {
-            syn::Error::new(
+            MacroError::new(
                 wgsl_source_span,
-                format_args!(
+                format!(
                     "internal error: translator did not produce valid Rust: {}",
                     ErrorChain(&error)
                 ),

--- a/macros/src/parsing.rs
+++ b/macros/src/parsing.rs
@@ -1,0 +1,125 @@
+use proc_macro2::TokenTree as TokenTree2;
+
+// -------------------------------------------------------------------------------------------------
+
+/// Wrapper around a token stream iterator which provides help with parsing.
+/// Performs a similar function to `syn::ParseStream`.
+pub(crate) struct Parser {
+    previous_token_span: Option<proc_macro2::Span>,
+    iter: proc_macro2::token_stream::IntoIter,
+}
+
+impl Parser {
+    pub fn from_token_stream(token_stream: proc_macro2::TokenStream) -> Self {
+        Self {
+            previous_token_span: None,
+            iter: token_stream.into_iter(),
+        }
+    }
+
+    /// Consume the next token, if there is one.
+    pub fn next(&mut self) -> Option<TokenTree2> {
+        self.iter
+            .next()
+            .inspect(|token| self.previous_token_span = Some(token.span()))
+    }
+
+    /// Consume the next token, and return an error if there isn’t one.
+    pub fn next_expect(&mut self, expected_thing: &'static str) -> Result<TokenTree2, MacroError> {
+        match self.next() {
+            Some(token) => Ok(token),
+            None => Err(if let Some(span) = self.previous_token_span {
+                MacroError::new(
+                    span,
+                    format!("expected {expected_thing}; found nothing after this"),
+                )
+            } else {
+                MacroError::new(
+                    proc_macro2::Span::call_site(),
+                    format!("expected {expected_thing}; found empty input"),
+                )
+            }),
+        }
+    }
+
+    // Note: The following parsing methods are inflexible in that they don’t take an expected_thing
+    // nor return a span. This is just because we don’t have uses for those, not because they
+    // wouldn’t make sense if we did.
+
+    pub fn expect_ident(&mut self) -> Result<String, MacroError> {
+        match unwrap_invisible_groups(self.next_expect("identifier")?) {
+            TokenTree2::Ident(ident) => Ok(ident.to_string()),
+            other => Err(MacroError::unexpected_token(&other, "an identifier")),
+        }
+    }
+
+    pub fn expect_bool(&mut self) -> Result<bool, MacroError> {
+        let token = unwrap_invisible_groups(self.next_expect("a boolean literal")?);
+        match litrs::BoolLit::try_from(&token) {
+            Ok(lit) => Ok(lit.value()),
+            Err(_) => Err(MacroError::unexpected_token(&token, "a boolean literal")),
+        }
+    }
+}
+
+/// Removes invisible groups, which may occur if our input tokens were partially produced by a
+/// `macro_rules!` macro.
+pub fn unwrap_invisible_groups(mut token: TokenTree2) -> TokenTree2 {
+    loop {
+        match token {
+            TokenTree2::Group(ref group) if group.delimiter() == proc_macro2::Delimiter::None => {
+                let mut it = group.stream().into_iter();
+                let Some(inner_token) = it.next() else {
+                    // no inner token
+                    return token;
+                };
+                if it.next().is_some() {
+                    // more than 1 inner token
+                    return token;
+                }
+                token = inner_token;
+            }
+            _ => break token,
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+/// Error that can be converted to a [`compile_error!`] invocation.
+#[derive(Debug)]
+pub(crate) struct MacroError {
+    pub span: proc_macro2::Span,
+    pub message: String,
+}
+
+impl MacroError {
+    pub fn new(span: proc_macro2::Span, message: String) -> Self {
+        Self { span, message }
+    }
+
+    pub fn unexpected_token(found: &proc_macro2::TokenTree, expected_thing: &'static str) -> Self {
+        match found {
+            TokenTree2::Group(group) => {
+                // Special error case to not print the entire group, which might be long.
+                Self::new(
+                    group.span(),
+                    format!("expected {expected_thing}; found group"),
+                )
+            }
+            other => Self::new(
+                other.span(),
+                format!("expected {expected_thing}; found `{other}`"),
+            ),
+        }
+    }
+
+    pub fn to_compile_error(&self) -> proc_macro::TokenStream {
+        // TODO: There are no tests which demonstrate that this does its job properly.
+        let Self { span, ref message } = *self;
+        quote::quote_spanned! {
+            span => ::core::compile_error!(#message);
+        }
+        .into()
+    }
+}

--- a/macros/src/tests.rs
+++ b/macros/src/tests.rs
@@ -10,53 +10,52 @@ use crate::ConfigAndStr;
 // -------------------------------------------------------------------------------------------------
 
 fn expect_error(input: proc_macro2::TokenStream) -> String {
-    match syn::parse2::<ConfigAndStr>(input) {
-        Ok(_) => panic!("no error"),
-        Err(e) => e.to_string(),
-    }
+    ConfigAndStr::parse(input).unwrap_err().message
 }
 
 #[test]
 fn success_without_config() {
     let input = quote! { r#"foo("bar");"# };
-    let parsed = syn::parse2::<ConfigAndStr>(input).unwrap();
-    assert_eq!(parsed.string.value(), r#"foo("bar");"#);
+    let parsed = ConfigAndStr::parse(input).unwrap();
+    assert_eq!(parsed.string, r#"foo("bar");"#);
 }
 
 #[test]
 fn success_with_comma() {
     let input = quote! { r#"foo("bar");"#, };
-    let parsed = syn::parse2::<ConfigAndStr>(input).unwrap();
-    assert_eq!(parsed.string.value(), r#"foo("bar");"#);
+    let parsed = ConfigAndStr::parse(input).unwrap();
+    assert_eq!(parsed.string, r#"foo("bar");"#);
 }
 
 #[test]
 fn success_with_config() {
     let input = quote! { allow_unimplemented = true, r#"foo("bar");"#, };
-    let parsed = syn::parse2::<ConfigAndStr>(input).unwrap();
+    let parsed = ConfigAndStr::parse(input).unwrap();
     // TODO: add an escape hatch so we can check the result of config parsing here
-    assert_eq!(parsed.string.value(), r#"foo("bar");"#);
+    assert_eq!(parsed.string, r#"foo("bar");"#);
 }
 
 #[test]
 fn empty() {
     assert_eq!(
         expect_error(quote! {}),
-        "unexpected end of input, expected identifier"
+        "expected a string literal or configuration option; found empty input"
     );
 }
 
 #[test]
 fn wrong_first_token() {
-    assert_eq!(expect_error(quote! { ! }), "expected identifier");
+    assert_eq!(
+        expect_error(quote! { ! }),
+        "expected a string literal or configuration option; found `!`"
+    );
 }
 
 #[test]
 fn wrong_literal() {
     assert_eq!(
         expect_error(quote! { 3.0 }),
-        // TODO: this is not a good error.
-        "unexpected end of input, expected identifier"
+        "expected a string literal or configuration option; found `3.0`"
     );
 }
 
@@ -72,7 +71,7 @@ fn unrecognized_config() {
 fn config_without_comma() {
     assert_eq!(
         expect_error(quote! { allow_unimplemented = true "" }),
-        "expected `,`"
+        r#"expected comma; found `""`"#
     );
 }
 
@@ -80,7 +79,7 @@ fn config_without_comma() {
 fn config_non_boolean() {
     assert_eq!(
         expect_error(quote! { allow_unimplemented = 3, "" }),
-        "expected boolean literal"
+        "expected a boolean literal; found `3`"
     );
 }
 
@@ -88,11 +87,14 @@ fn config_non_boolean() {
 fn config_non_ident() {
     assert_eq!(
         expect_error(quote! { global_struct = 3, "" }),
-        "expected identifier"
+        "expected an identifier; found `3`"
     );
 }
 
 #[test]
 fn non_comma_after_input() {
-    assert_eq!(expect_error(quote! { ""+ }), "expected `,`");
+    assert_eq!(
+        expect_error(quote! { ""+ }),
+        "expected comma or nothing; found `+`"
+    );
 }


### PR DESCRIPTION
This replaces a heavy dependency with a lighter one, and avoids the question of how promptly we should update from `syn` 2 to `syn` 3. `litrs` is already in the transitive dependencies of `wgpu` users via `document-features`, so most of the programs that might use `naga-rust` probably already have `litrs` too.

We don’t actually need any of `syn`’s Rust grammar to parse our configuration syntax. If, in the future, we want a syntax that contains Rust expressions, we can either revert this change, or require that those expressions are always parenthesized.