### PR TITLE
Add tests for macro syntax errors.

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -14,7 +14,7 @@ license.workspace = true
 
 [lib]
 proc-macro = true
-test = false
+test = true # syntax error tests only
 doctest = false
 
 [dependencies]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -16,6 +16,13 @@ use syn::Token;
 use naga_rust_back::Config;
 use naga_rust_back::naga;
 
+// -------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests;
+
+// -------------------------------------------------------------------------------------------------
+
 #[proc_macro]
 pub fn include_wgsl_mr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ConfigAndStr {
@@ -106,10 +113,8 @@ impl syn::parse::Parse for ConfigAndStr {
                     config = config.resource_struct(input.parse::<syn::Ident>()?.to_string());
                 }
                 _ => {
-                    return Err(syn::Error::new_spanned(
-                        option_name,
-                        "unrecognized configuration option name",
-                    ));
+                    let msg = format!("`{option_name}` is not the name of a configuration option");
+                    return Err(syn::Error::new_spanned(option_name, msg));
                 }
             }
             input.parse::<Token![,]>()?;

--- a/macros/src/tests.rs
+++ b/macros/src/tests.rs
@@ -1,0 +1,98 @@
+//! Tests of syntax errors on the input to our macros.
+//!
+//! These tests are not perfectly realistic, but they are much cheaper than invoking rustc and
+//! require less setup.
+
+use quote::quote;
+
+use crate::ConfigAndStr;
+
+// -------------------------------------------------------------------------------------------------
+
+fn expect_error(input: proc_macro2::TokenStream) -> String {
+    match syn::parse2::<ConfigAndStr>(input) {
+        Ok(_) => panic!("no error"),
+        Err(e) => e.to_string(),
+    }
+}
+
+#[test]
+fn success_without_config() {
+    let input = quote! { r#"foo("bar");"# };
+    let parsed = syn::parse2::<ConfigAndStr>(input).unwrap();
+    assert_eq!(parsed.string.value(), r#"foo("bar");"#);
+}
+
+#[test]
+fn success_with_comma() {
+    let input = quote! { r#"foo("bar");"#, };
+    let parsed = syn::parse2::<ConfigAndStr>(input).unwrap();
+    assert_eq!(parsed.string.value(), r#"foo("bar");"#);
+}
+
+#[test]
+fn success_with_config() {
+    let input = quote! { allow_unimplemented = true, r#"foo("bar");"#, };
+    let parsed = syn::parse2::<ConfigAndStr>(input).unwrap();
+    // TODO: add an escape hatch so we can check the result of config parsing here
+    assert_eq!(parsed.string.value(), r#"foo("bar");"#);
+}
+
+#[test]
+fn empty() {
+    assert_eq!(
+        expect_error(quote! {}),
+        "unexpected end of input, expected identifier"
+    );
+}
+
+#[test]
+fn wrong_first_token() {
+    assert_eq!(expect_error(quote! { ! }), "expected identifier");
+}
+
+#[test]
+fn wrong_literal() {
+    assert_eq!(
+        expect_error(quote! { 3.0 }),
+        // TODO: this is not a good error.
+        "unexpected end of input, expected identifier"
+    );
+}
+
+#[test]
+fn unrecognized_config() {
+    assert_eq!(
+        expect_error(quote! { unknown_option = true, "" }),
+        "`unknown_option` is not the name of a configuration option"
+    );
+}
+
+#[test]
+fn config_without_comma() {
+    assert_eq!(
+        expect_error(quote! { allow_unimplemented = true "" }),
+        "expected `,`"
+    );
+}
+
+#[test]
+fn config_non_boolean() {
+    assert_eq!(
+        expect_error(quote! { allow_unimplemented = 3, "" }),
+        "expected boolean literal"
+    );
+}
+
+#[test]
+fn config_non_ident() {
+    assert_eq!(
+        expect_error(quote! { global_struct = 3, "" }),
+        "expected identifier"
+    );
+}
+
+#[test]
+fn non_comma_after_input() {
+    assert_eq!(expect_error(quote! { ""+ }), "expected `,`");
+}


### PR DESCRIPTION
Note that these tests do not necessarily represent *good* errors, just the current ones, except for a change to the configuration option error; and they do not test the span of the error or consequences of the spans of the inputs. They are primarily intended to add test coverage before more major changes to parsing.