### PR TITLE
macros: Remove `quote` dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -24,6 +24,8 @@ litrs = { version = "1.0.0", features = ["proc-macro2"] }
 naga = { workspace = true, features = ["wgsl-in"] }
 naga-rust-back.workspace = true
 proc-macro2.workspace = true
+
+[dev-dependencies]
 quote = "1.0.37"
 
 [lints]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -10,10 +10,15 @@ use std::fmt;
 use std::fs;
 use std::path::PathBuf;
 
+use proc_macro2::Delimiter;
+use proc_macro2::Group;
+use proc_macro2::Ident;
+use proc_macro2::Literal;
+use proc_macro2::Punct;
+use proc_macro2::Spacing;
 use proc_macro2::Span;
 use proc_macro2::TokenStream;
 use proc_macro2::TokenTree;
-use quote::quote;
 
 use naga_rust_back::Config;
 use naga_rust_back::naga;
@@ -21,7 +26,7 @@ use naga_rust_back::naga;
 // -------------------------------------------------------------------------------------------------
 
 mod parsing;
-use parsing::{MacroError, Parser, unwrap_invisible_groups};
+use parsing::{MacroError, Parser, simple_path_to_tokens, unwrap_invisible_groups};
 
 #[cfg(test)]
 mod tests;
@@ -222,13 +227,40 @@ fn include_wgsl_mr_impl(
 
     let translated_tokens = parse_and_translate(config, path_span, &wgsl_source_text)?;
 
-    Ok(quote! {
-        // Dummy include_str! call tells the compiler that we depend on this file,
-        // which it would not notice otherwise.
-        const _: &str = include_str!(#absolute_path_str);
-
-        #translated_tokens
-    })
+    // Dummy include_str! call tells the compiler that we depend on this file,
+    // which it would not notice otherwise.
+    let generated_span = Span::mixed_site(); // ideally would be def_site
+    Ok(TokenStream::from_iter(
+        [
+            TokenTree::Ident(Ident::new("const", generated_span)),
+            TokenTree::Ident(Ident::new("_", generated_span)),
+            TokenTree::Punct(Punct::new(':', Spacing::Alone)),
+            TokenTree::Punct(Punct::new('&', Spacing::Alone)),
+        ]
+        .into_iter()
+        .chain(simple_path_to_tokens(
+            generated_span,
+            &["core", "primitive", "str"],
+        ))
+        .chain([TokenTree::Punct(Punct::new('=', Spacing::Alone))])
+        .chain(simple_path_to_tokens(
+            generated_span,
+            &["core", "include_str"],
+        ))
+        .chain([
+            TokenTree::Punct(Punct::new('!', Spacing::Alone)),
+            TokenTree::Group(Group::new(
+                Delimiter::Parenthesis,
+                TokenStream::from(TokenTree::Literal({
+                    let mut lit = Literal::string(absolute_path_str);
+                    lit.set_span(path_span);
+                    lit
+                })),
+            )),
+            TokenTree::Punct(Punct::new(';', Spacing::Alone)),
+        ])
+        .chain(translated_tokens),
+    ))
 }
 
 fn parse_and_translate(

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -10,7 +10,9 @@ use std::fmt;
 use std::fs;
 use std::path::PathBuf;
 
-use proc_macro2::TokenTree as TokenTree2;
+use proc_macro2::Span;
+use proc_macro2::TokenStream;
+use proc_macro2::TokenTree;
 use quote::quote;
 
 use naga_rust_back::Config;
@@ -72,19 +74,19 @@ pub fn dummy_attribute(
 #[derive(Debug)]
 struct ConfigAndStr {
     config: Config,
-    string_span: proc_macro2::Span,
+    string_span: Span,
     string: String,
 }
 
 impl ConfigAndStr {
-    fn parse(input: proc_macro2::TokenStream) -> Result<Self, MacroError> {
+    fn parse(input: TokenStream) -> Result<Self, MacroError> {
         const EXPECT_TOP_LEVEL: &str = "a string literal or configuration option";
         let mut config = macro_default_config();
         let mut input = Parser::from_token_stream(input);
         loop {
             match unwrap_invisible_groups(input.next_expect(EXPECT_TOP_LEVEL)?) {
                 // A literal must be the final string.
-                ref tt @ TokenTree2::Literal(ref literal_token) => {
+                ref tt @ TokenTree::Literal(ref literal_token) => {
                     let quoted: String = literal_token.to_string();
                     let unquoted: String = match litrs::StringLit::try_from(literal_token) {
                         Ok(sl) => sl.into_value(),
@@ -103,7 +105,7 @@ impl ConfigAndStr {
 
                     // Accept a final optional comma after the string.
                     match input.next() {
-                        Some(TokenTree2::Punct(punct)) if punct.as_char() == ',' => {}
+                        Some(TokenTree::Punct(punct)) if punct.as_char() == ',' => {}
                         None => {}
                         Some(other) => {
                             return Err(MacroError::unexpected_token(&other, "comma or nothing"));
@@ -118,11 +120,11 @@ impl ConfigAndStr {
                 }
 
                 // An identifier must be the name of a configuration option.
-                TokenTree2::Ident(option_name_ident) => {
+                TokenTree::Ident(option_name_ident) => {
                     let option_name = option_name_ident.to_string();
 
                     match input.next_expect("`=`")? {
-                        TokenTree2::Punct(punct) if punct.as_char() == '=' => {}
+                        TokenTree::Punct(punct) if punct.as_char() == '=' => {}
                         other => {
                             return Err(MacroError::unexpected_token(&other, "`=`"));
                         }
@@ -163,7 +165,7 @@ impl ConfigAndStr {
                     }
 
                     match input.next_expect("comma")? {
-                        TokenTree2::Punct(punct) if punct.as_char() == ',' => {}
+                        TokenTree::Punct(punct) if punct.as_char() == ',' => {}
                         other => {
                             return Err(MacroError::unexpected_token(&other, "comma"));
                         }
@@ -190,9 +192,9 @@ fn macro_default_config() -> Config {
 
 fn include_wgsl_mr_impl(
     config: Config,
-    path_span: proc_macro2::Span,
+    path_span: Span,
     path_text: &str,
-) -> Result<proc_macro2::TokenStream, MacroError> {
+) -> Result<TokenStream, MacroError> {
     // We use manifest-relative paths because currently, there is no way to arrange for
     // source-file-relative paths.
     let mut absolute_path: PathBuf = PathBuf::from(
@@ -231,9 +233,9 @@ fn include_wgsl_mr_impl(
 
 fn parse_and_translate(
     config: Config,
-    wgsl_source_span: proc_macro2::Span,
+    wgsl_source_span: Span,
     wgsl_source_text: &str,
-) -> Result<proc_macro2::TokenStream, MacroError> {
+) -> Result<TokenStream, MacroError> {
     let module: naga::Module = naga::front::wgsl::parse_str(wgsl_source_text).map_err(|error| {
         MacroError::new(
             wgsl_source_span,
@@ -265,16 +267,15 @@ fn parse_and_translate(
             )
         })?;
 
-    let translated_tokens: proc_macro2::TokenStream =
-        translated_source.parse().map_err(|error| {
-            MacroError::new(
-                wgsl_source_span,
-                format!(
-                    "internal error: translator did not produce valid Rust: {}",
-                    ErrorChain(&error)
-                ),
-            )
-        })?;
+    let translated_tokens: TokenStream = translated_source.parse().map_err(|error| {
+        MacroError::new(
+            wgsl_source_span,
+            format!(
+                "internal error: translator did not produce valid Rust: {}",
+                ErrorChain(&error)
+            ),
+        )
+    })?;
 
     Ok(translated_tokens)
 }

--- a/macros/src/parsing.rs
+++ b/macros/src/parsing.rs
@@ -1,4 +1,5 @@
-use proc_macro2::TokenTree as TokenTree2;
+use proc_macro2::Delimiter;
+use proc_macro2::TokenTree;
 
 // -------------------------------------------------------------------------------------------------
 
@@ -18,14 +19,14 @@ impl Parser {
     }
 
     /// Consume the next token, if there is one.
-    pub fn next(&mut self) -> Option<TokenTree2> {
+    pub fn next(&mut self) -> Option<TokenTree> {
         self.iter
             .next()
             .inspect(|token| self.previous_token_span = Some(token.span()))
     }
 
     /// Consume the next token, and return an error if there isn’t one.
-    pub fn next_expect(&mut self, expected_thing: &'static str) -> Result<TokenTree2, MacroError> {
+    pub fn next_expect(&mut self, expected_thing: &'static str) -> Result<TokenTree, MacroError> {
         match self.next() {
             Some(token) => Ok(token),
             None => Err(if let Some(span) = self.previous_token_span {
@@ -48,7 +49,7 @@ impl Parser {
 
     pub fn expect_ident(&mut self) -> Result<String, MacroError> {
         match unwrap_invisible_groups(self.next_expect("identifier")?) {
-            TokenTree2::Ident(ident) => Ok(ident.to_string()),
+            TokenTree::Ident(ident) => Ok(ident.to_string()),
             other => Err(MacroError::unexpected_token(&other, "an identifier")),
         }
     }
@@ -64,10 +65,10 @@ impl Parser {
 
 /// Removes invisible groups, which may occur if our input tokens were partially produced by a
 /// `macro_rules!` macro.
-pub fn unwrap_invisible_groups(mut token: TokenTree2) -> TokenTree2 {
+pub fn unwrap_invisible_groups(mut token: TokenTree) -> TokenTree {
     loop {
         match token {
-            TokenTree2::Group(ref group) if group.delimiter() == proc_macro2::Delimiter::None => {
+            TokenTree::Group(ref group) if group.delimiter() == Delimiter::None => {
                 let mut it = group.stream().into_iter();
                 let Some(inner_token) = it.next() else {
                     // no inner token
@@ -98,9 +99,9 @@ impl MacroError {
         Self { span, message }
     }
 
-    pub fn unexpected_token(found: &proc_macro2::TokenTree, expected_thing: &'static str) -> Self {
+    pub fn unexpected_token(found: &TokenTree, expected_thing: &'static str) -> Self {
         match found {
-            TokenTree2::Group(group) => {
+            TokenTree::Group(group) => {
                 // Special error case to not print the entire group, which might be long.
                 Self::new(
                     group.span(),

--- a/macros/src/parsing.rs
+++ b/macros/src/parsing.rs
@@ -1,4 +1,9 @@
 use proc_macro2::Delimiter;
+use proc_macro2::Group;
+use proc_macro2::Ident;
+use proc_macro2::Punct;
+use proc_macro2::Spacing;
+use proc_macro2::Span;
 use proc_macro2::TokenTree;
 
 // -------------------------------------------------------------------------------------------------
@@ -6,7 +11,7 @@ use proc_macro2::TokenTree;
 /// Wrapper around a token stream iterator which provides help with parsing.
 /// Performs a similar function to `syn::ParseStream`.
 pub(crate) struct Parser {
-    previous_token_span: Option<proc_macro2::Span>,
+    previous_token_span: Option<Span>,
     iter: proc_macro2::token_stream::IntoIter,
 }
 
@@ -36,7 +41,7 @@ impl Parser {
                 )
             } else {
                 MacroError::new(
-                    proc_macro2::Span::call_site(),
+                    Span::call_site(),
                     format!("expected {expected_thing}; found empty input"),
                 )
             }),
@@ -90,12 +95,12 @@ pub fn unwrap_invisible_groups(mut token: TokenTree) -> TokenTree {
 /// Error that can be converted to a [`compile_error!`] invocation.
 #[derive(Debug)]
 pub(crate) struct MacroError {
-    pub span: proc_macro2::Span,
+    pub span: Span,
     pub message: String,
 }
 
 impl MacroError {
-    pub fn new(span: proc_macro2::Span, message: String) -> Self {
+    pub fn new(span: Span, message: String) -> Self {
         Self { span, message }
     }
 
@@ -118,9 +123,36 @@ impl MacroError {
     pub fn to_compile_error(&self) -> proc_macro::TokenStream {
         // TODO: There are no tests which demonstrate that this does its job properly.
         let Self { span, ref message } = *self;
-        quote::quote_spanned! {
-            span => ::core::compile_error!(#message);
-        }
+
+        proc_macro2::TokenStream::from_iter(
+            simple_path_to_tokens(span, &["core", "compile_error"])
+                .chain([
+                    TokenTree::Punct(Punct::new('!', Spacing::Alone)),
+                    TokenTree::Group(Group::new(
+                        Delimiter::Parenthesis,
+                        proc_macro2::TokenStream::from(TokenTree::Literal(
+                            proc_macro2::Literal::string(message),
+                        )),
+                    )),
+                    TokenTree::Punct(Punct::new(';', Spacing::Alone)),
+                ])
+                .map(|mut token| {
+                    token.set_span(span);
+                    token
+                }),
+        )
         .into()
     }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+pub(crate) fn simple_path_to_tokens(span: Span, path: &[&str]) -> impl Iterator<Item = TokenTree> {
+    path.iter().flat_map(move |segment| {
+        [
+            TokenTree::Punct(Punct::new(':', Spacing::Joint)),
+            TokenTree::Punct(Punct::new(':', Spacing::Alone)),
+            TokenTree::Ident(Ident::new(segment, span)),
+        ]
+    })
 }


### PR DESCRIPTION
It’s still used for tests but not for the library.