### PR TITLE
Add bytemuck trait implementations.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     strategy:
       matrix:
         toolchain: ["stable", "beta", "nightly", "1.87.0"]
+        features: ["--all-features", "--no-default-features"]
 
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.toolchain != 'stable' }}
@@ -52,11 +53,11 @@ jobs:
     # As a substitute, we always test on minimal and maximal versions.
     - run: cargo +nightly update -Zdirect-minimal-versions
 
-    - run: cargo test --all-features
+    - run: cargo test ${{ matrix.features }}
 
     - run: cargo update
 
-    - run: cargo test --all-features
+    - run: cargo test ${{ matrix.features }}
 
   miri:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,10 +883,12 @@ dependencies = [
 name = "naga-rust-rt"
 version = "0.2.0"
 dependencies = [
+ "bytemuck",
  "mutants",
  "naga-rust-macros",
  "num-traits",
  "paste",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ naga-rust-rt = { version = "0.2.0", path = "rt" }
 
 arrayvec = { version = "0.7.6", default-features = false }
 bitflags = "2.9"
+bytemuck = { version = "1.25.0", default-features = false }
 exhaust = { version = "0.2.0", default-features = false }
 half = { version = "2.5" } # must agree with version used by naga version
 indoc = { version = "2.0.1", default-features = false }
@@ -39,6 +40,7 @@ paste = {version = "1.0.15", default-features = false }
 pollster = { version = "1.0.0", default-features = false }
 pretty_assertions = { version = "1.2.0" }
 proc-macro2 = { version = "1.0.91", default-features = false }
+static_assertions = { version = "1.1.0", default-features = false }
 
 [workspace.lints.rust]
 # rustc lints that are set to deny

--- a/embed/CHANGELOG.md
+++ b/embed/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Unreleased
 
-## Added
+### Added
 
 * Configuration `include_functions`, if disabled, allows translating only `struct`s and `const`s.
+* Implementations of [`bytemuck` v1](https://docs.rs/bytemuck/1/bytemuck/)’s traits for our scalar, vector, and matrix types, with `features = ["bytemuck"]`.
+  Note that this does not implemented the traits on translated `struct` types.
 
-## Changed
+### Changed
 
 * The `naga` version is now 30.
 * The macros’ parsing code has been rewritten.

--- a/embed/Cargo.toml
+++ b/embed/Cargo.toml
@@ -19,6 +19,9 @@ keywords = [
 
 [features]
 default = []
+# Implement `bytemuck` traits for `naga_rust_embed::rt` types.
+# This does not affect generated code; that must be configured separately.
+bytemuck = ["naga-rust-rt/bytemuck"]
 
 [dependencies]
 naga-rust-macros.workspace = true

--- a/rt/CHANGELOG.md
+++ b/rt/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for `naga-rust-rt`
 
+## Unreleased
+
+### Added
+
+* Implementations of [`bytemuck` v1](https://docs.rs/bytemuck/1/bytemuck/)’s traits for our scalar, vector, and matrix types, with `features = ["bytemuck"]`.
+
 ## 0.2.0 (2026-05-14)
 
 ### Added

--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -20,18 +20,29 @@ license.workspace = true
 test = false
 doctest = false
 
+[[test]]
+name = "bytemuck"
+required-features = ["bytemuck"]
+
 [features]
 default = []
 # If enabled, implement texture access traits for `Box`, `Rc`, and `Arc`
 alloc = []
 # If enabled, use `std`’s math functions instead of `libm`’s
 std = []
+# Implement `bytemuck` traits for our types.
+bytemuck = ["dep:bytemuck"]
 
 [dependencies]
+bytemuck = { workspace = true, optional = true }
 mutants.workspace = true
 num-traits = { workspace = true, default-features = false, features = ["libm"] }
 naga-rust-macros.workspace = true
 paste.workspace = true
+
+[dev-dependencies]
+bytemuck = { workspace = true, features = ["must_cast"] }
+static_assertions.workspace = true
 
 [lints.clippy]
 std_instead_of_alloc = "warn"

--- a/rt/src/matrix.rs
+++ b/rt/src/matrix.rs
@@ -2,6 +2,9 @@ use core::ops;
 
 use crate::{Scalar, Vec2, Vec3, Vec4};
 
+#[cfg(feature = "bytemuck")]
+use ::bytemuck as bm;
+
 // -------------------------------------------------------------------------------------------------
 
 /// Generate a row vector from a matrix.
@@ -198,6 +201,18 @@ macro_rules! matrix_struct {
                     )
                 }
             }
+
+            // SAFETY: This type has a layout equivalent to `[T; N]`, which is
+            // sufficient for `AnyBitPattern`, `NoUninit`, and `Zeroable` to be correct;
+            // in particular, the matrix will never have padding that `T` does not.
+            //
+            // We are not using `bytemuck` derives because they do not support generic types.
+            #[cfg(feature = "bytemuck")]
+            unsafe impl<T: bm::AnyBitPattern> bm::AnyBitPattern for [< Mat $columns x $rows >]<T> {}
+            #[cfg(feature = "bytemuck")]
+            unsafe impl<T: bm::NoUninit> bm::NoUninit for [< Mat $columns x $rows >]<T> {}
+            #[cfg(feature = "bytemuck")]
+            unsafe impl<T: bm::Zeroable> bm::Zeroable for [< Mat $columns x $rows >]<T> {}
         }
     }
 }

--- a/rt/src/vector.rs
+++ b/rt/src/vector.rs
@@ -1005,3 +1005,31 @@ impl<T: Copy> Vec4<T> {
     swizzle_fn!(wzxy Vec4(w z x y));
     swizzle_fn!(wzyx Vec4(w z y x));
 }
+
+// -------------------------------------------------------------------------------------------------
+
+#[cfg(feature = "bytemuck")]
+mod impl_bytemuck {
+    use super::*;
+
+    // SAFETY: All of these types have layout equivalent to `[T; N]`,
+    // which is sufficient for `AnyBitPattern`, `NoUninit`, and `Zeroable` to be correct.
+    // in particular, each vector will never have padding that `T` does not.
+    //
+    // We are not using `bytemuck` derives because they do not support generic types.
+
+    unsafe impl<T: bytemuck::AnyBitPattern> bytemuck::AnyBitPattern for Scalar<T> {}
+    unsafe impl<T: bytemuck::AnyBitPattern> bytemuck::AnyBitPattern for Vec2<T> {}
+    unsafe impl<T: bytemuck::AnyBitPattern> bytemuck::AnyBitPattern for Vec3<T> {}
+    unsafe impl<T: bytemuck::AnyBitPattern> bytemuck::AnyBitPattern for Vec4<T> {}
+
+    unsafe impl<T: bytemuck::NoUninit> bytemuck::NoUninit for Scalar<T> {}
+    unsafe impl<T: bytemuck::NoUninit> bytemuck::NoUninit for Vec2<T> {}
+    unsafe impl<T: bytemuck::NoUninit> bytemuck::NoUninit for Vec3<T> {}
+    unsafe impl<T: bytemuck::NoUninit> bytemuck::NoUninit for Vec4<T> {}
+
+    unsafe impl<T: bytemuck::Zeroable> bytemuck::Zeroable for Scalar<T> {}
+    unsafe impl<T: bytemuck::Zeroable> bytemuck::Zeroable for Vec2<T> {}
+    unsafe impl<T: bytemuck::Zeroable> bytemuck::Zeroable for Vec3<T> {}
+    unsafe impl<T: bytemuck::Zeroable> bytemuck::Zeroable for Vec4<T> {}
+}

--- a/rt/tests/bytemuck.rs
+++ b/rt/tests/bytemuck.rs
@@ -1,0 +1,70 @@
+extern crate naga_rust_rt as rt;
+
+use bytemuck::{AnyBitPattern, NoUninit, Zeroable};
+
+#[test]
+fn cast_from_scalar() {
+    assert_eq!(
+        bytemuck::must_cast::<rt::Scalar<f32>, f32>(rt::Scalar(1.0)),
+        1.0
+    );
+}
+
+#[test]
+fn cast_to_scalar() {
+    assert_eq!(
+        bytemuck::must_cast::<f32, rt::Scalar<f32>>(1.0),
+        rt::Scalar(1.0)
+    );
+}
+
+#[test]
+fn cast_from_vector() {
+    assert_eq!(
+        bytemuck::must_cast::<rt::Vec2<f32>, [f32; 2]>(rt::Vec2::new(1.0, 2.0)),
+        [1.0, 2.0]
+    );
+}
+
+#[test]
+fn cast_to_vector() {
+    assert_eq!(
+        bytemuck::must_cast::<[f32; 2], rt::Vec2<f32>>([1.0, 2.0]),
+        rt::Vec2::new(1.0, 2.0)
+    );
+}
+
+#[test]
+fn cast_from_matrix() {
+    assert_eq!(
+        bytemuck::must_cast::<rt::Mat2x2<f32>, [[f32; 2]; 2]>(rt::Mat2x2::new(
+            rt::Vec2::new(1.0, 2.0),
+            rt::Vec2::new(3.0, 4.0)
+        )),
+        [[1.0, 2.0], [3.0, 4.0]]
+    );
+}
+
+#[test]
+fn cast_to_matrix() {
+    assert_eq!(
+        bytemuck::must_cast::<[[f32; 2]; 2], rt::Mat2x2<f32>>([[1.0, 2.0], [3.0, 4.0]]),
+        rt::Mat2x2::new(rt::Vec2::new(1.0, 2.0), rt::Vec2::new(3.0, 4.0))
+    );
+}
+
+// Test that bytemuck traits are not implemented when not implementing them would be unsound.
+// Note we don’t have 100% coverage for matrix types, but that’s okay because we use a macro to
+// generate them consistently.
+// Pointer types implement no traits:
+static_assertions::assert_not_impl_any!(rt::Scalar<Box<f32>>: Zeroable, NoUninit, AnyBitPattern);
+static_assertions::assert_not_impl_any!(rt::Vec2<Box<f32>>: Zeroable, NoUninit, AnyBitPattern);
+static_assertions::assert_not_impl_any!(rt::Vec3<Box<f32>>: Zeroable, NoUninit, AnyBitPattern);
+static_assertions::assert_not_impl_any!(rt::Vec4<Box<f32>>: Zeroable, NoUninit, AnyBitPattern);
+static_assertions::assert_not_impl_any!(rt::Mat2x2<Box<f32>>: Zeroable, NoUninit, AnyBitPattern);
+// If the element is not AnyBitPattern then neither is the container:
+static_assertions::assert_not_impl_any!(rt::Scalar<bool>: AnyBitPattern);
+static_assertions::assert_not_impl_any!(rt::Vec2<bool>: AnyBitPattern);
+static_assertions::assert_not_impl_any!(rt::Vec3<bool>: AnyBitPattern);
+static_assertions::assert_not_impl_any!(rt::Vec4<bool>: AnyBitPattern);
+static_assertions::assert_not_impl_any!(rt::Mat2x2<bool>: AnyBitPattern);


### PR DESCRIPTION
This is a quick implementation to unblock the use case of CPU/GPU interop using translated structs. Future work could include adding corresponding `zerocopy` trait implementations, or adding a configuration option which changes how `struct`s and uniforms are translated, so that they can be arrays instead of our own types.