### PR TITLE
Add methods for conversion from/to arrays.

### DIFF
--- a/rt/CHANGELOG.md
+++ b/rt/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+* `Vec*::from_array()`
+* `Vec*::to_array()`
+* `Mat*::from_column_arrays()`
+* `Mat*::to_column_arrays()`
 * Implementations of [`bytemuck` v1](https://docs.rs/bytemuck/1/bytemuck/)’s traits for our scalar, vector, and matrix types, with `features = ["bytemuck"]`.
 
 ## 0.2.0 (2026-05-14)

--- a/rt/src/matrix.rs
+++ b/rt/src/matrix.rs
@@ -71,8 +71,22 @@ macro_rules! matrix_struct {
             }
 
             impl<T> [< Mat $columns x $rows >] <T> {
-                pub fn new($([< $column_field _column >]: $column_type<T>,)*) -> Self {
+                pub const fn new($([< $column_field _column >]: $column_type<T>,)*) -> Self {
                     Self { $($column_field: [< $column_field _column >],)* }
+                }
+
+                pub const fn from_column_arrays(columns: [[T; $rows]; $columns]) -> Self
+                where
+                    // Note: Copy bound is solely due to otherwise needing
+                    // `feature(const_precise_live_drops)`.
+                    T: Copy
+                {
+                    let [$( $column_field ),*] = columns;
+                    Self {
+                        $(
+                            $column_field: $column_type::from_array($column_field),
+                        )*
+                    }
                 }
 
                 pub fn transpose(self) -> [< Mat $rows x $columns >] <T> {
@@ -83,6 +97,20 @@ macro_rules! matrix_struct {
                         [$($row_field),*],
                         [$($column_field),*]
                     )
+                }
+
+                /// Convert the matrix into an array of column vectors as arrays.
+                ///
+                /// This function may be useful for interoperation with other vector libraries.
+                /// If a flat array is desired, call `transpose()` on it.
+                #[inline]
+                pub fn to_column_arrays(self) -> [[T; $rows]; $columns]
+                where
+                    // Note: Copy bound is solely due to otherwise needing
+                    // `feature(const_precise_live_drops)`.
+                    T: Copy
+                 {
+                    [$( self.$column_field.to_array() ),*]
                 }
 
                 #[inline]

--- a/rt/src/vector.rs
+++ b/rt/src/vector.rs
@@ -599,6 +599,16 @@ macro_rules! impl_vector_regular_fns {
             }
 
             #[inline]
+            pub const fn to_array(self) -> [T; $component_count]
+            where
+                // Note: Copy bound is solely due to otherwise needing
+                // `feature(const_precise_live_drops)`.
+                T: Copy
+            {
+                [$( self.$component, )* ]
+            }
+
+            #[inline]
             fn as_array_ref(&self) -> &[Scalar<T>; $component_count] {
                 // Reinterpret the reference to self as a reference to an array.
                 // SAFETY: Vectors are `repr(C)` and have the same elements as the array.
@@ -715,6 +725,7 @@ macro_rules! impl_vector_regular_fns {
 
         // Conversion in and out
         impl<T> From<$ty<T>> for [T; $component_count] {
+            #[inline]
             fn from(value: $ty<T>) -> Self {
                 [$( value.$component ),*]
             }
@@ -757,6 +768,14 @@ macro_rules! impl_vector_not_scalar_fns {
         impl<T> $ty<T> {
             // User-friendly constructor, not used by translated code.
             pub const fn new($( $component: T, )*) -> Self {
+                Self { $( $component, )* }
+            }
+
+            pub const fn from_array(values: [T; $component_count]) -> Self
+            where
+                T: Copy
+            {
+                let [$( $component ),*] = values;
                 Self { $( $component, )* }
             }
 


### PR DESCRIPTION
Some of these could already be done via `From`, but these functions are `const fn` and reduce the need for type annotations.