### PR TITLE
Add "rules" system.

### DIFF
--- a/back/src/config.rs
+++ b/back/src/config.rs
@@ -1,9 +1,13 @@
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
 
 use crate::ra;
 use crate::util::GlobalKind;
+
+// -------------------------------------------------------------------------------------------------
 
 /// Configuration/builder for options for Rust code generation.
 ///
@@ -17,6 +21,7 @@ pub struct Config {
     pub(crate) resource_struct: Option<String>,
     #[allow(dead_code, reason = "reminding ourselves of the future")]
     pub(crate) edition: Edition,
+    pub(crate) rules: Vec<Rule>,
 }
 
 impl Default for Config {
@@ -27,7 +32,7 @@ impl Default for Config {
 
 impl Config {
     // When adding new options, also add them to:
-    // * `ConfigAndStr::parse` in `macros/src/lib.rs`.
+    // * `ConfigAndStr::parse` in `macros/src/parse_config.rs`.
     // * `embed/src/configuration_syntax.md` (documentation for the macros).
 
     /// Creates a [`Config`] with default options.
@@ -39,6 +44,7 @@ impl Config {
             global_struct: None,
             resource_struct: None,
             edition: Edition::Rust2024,
+            rules: Vec::new(),
         }
     }
 
@@ -158,6 +164,15 @@ impl Config {
         self.resource_struct = Some(name.into());
         self
     }
+
+    /// Adds a rule.
+    ///
+    /// Rules modify the translation of specific parts of the shader code.
+    #[must_use]
+    pub fn rule(mut self, rule: impl Into<Rule>) -> Self {
+        self.rules.push(rule.into());
+        self
+    }
 }
 
 /// Internal methods that help generate code based on this config.
@@ -187,6 +202,24 @@ impl Config {
             (Some(GlobalKind::Resource), None) | (Some(GlobalKind::Variable), _) => ra::Expr::Self_,
             _ => unreachable!(),
         }
+    }
+
+    /// Iterates over the effects of all rules that apply in the given situation.
+    ///
+    /// Later rules should take priority over earlier rules (e.g. by overwriting a variable).
+    pub(crate) fn apply_rules(&self, input: &RuleInput<'_>) -> impl Iterator<Item = &Effect> {
+        self.rules.iter().flat_map(
+            |Rule {
+                 conditions: condition,
+                 effects,
+             }| {
+                if condition.iter().all(|c| c.test(input)) {
+                    effects.as_slice()
+                } else {
+                    &[]
+                }
+            },
+        )
     }
 }
 
@@ -223,4 +256,73 @@ bitflags::bitflags! {
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum Edition {
     Rust2024,
+}
+
+// -------------------------------------------------------------------------------------------------
+
+/// Controls some aspect of the translation from shader code to Rust that needs Rust-specific
+/// choices that cannot be expressed inside the shader code.
+///
+/// Put these in [`Config::rule()`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[allow(clippy::exhaustive_structs)]
+pub struct Rule {
+    /// The rule applies when all of these conditions are met.
+    pub conditions: Vec<Condition>,
+    /// The rule has all of these effects.
+    pub effects: Vec<Effect>,
+}
+
+/// Specifies a condition under which a [`Rule`] applies to a part of the input shader code.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Condition {
+    /// Applies to the struct with the given name (excluding resource and global structs).
+    Struct(String),
+}
+
+/// Specifies the effect of a [`Rule`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Effect {
+    /// Applies a derive macro to translated structs.
+    ///
+    /// The given string is copied literally into the output and must be a path to a derive macro,
+    /// as accepted by the `#[derive]` attribute.
+    Derive(String),
+}
+
+/// Data consulted by rules.
+pub(crate) struct RuleInput<'a> {
+    /// Shader struct name.
+    /// `None` if rules are being applied to something other than a struct item,
+    /// or a generated struct not corresponding to a shader struct.
+    pub r#struct: Option<&'a str>,
+}
+
+impl From<(Condition, Effect)> for Rule {
+    fn from((c, e): (Condition, Effect)) -> Self {
+        Self {
+            conditions: vec![c],
+            effects: vec![e],
+        }
+    }
+}
+
+impl From<Effect> for Rule {
+    /// Creates a rule that always applies.
+    fn from(e: Effect) -> Self {
+        Self {
+            conditions: vec![],
+            effects: vec![e],
+        }
+    }
+}
+
+impl Condition {
+    fn test(&self, input: &RuleInput<'_>) -> bool {
+        match *self {
+            Condition::Struct(ref name) => input.r#struct == Some(name.as_str()),
+        }
+    }
 }

--- a/back/src/lib.rs
+++ b/back/src/lib.rs
@@ -40,7 +40,7 @@ mod ra;
 mod util;
 mod writer;
 
-pub use config::Config;
+pub use config::{Condition, Config, Effect, Rule};
 pub use writer::Writer;
 
 /// The version of Naga we are compatible with.

--- a/back/src/ra.rs
+++ b/back/src/ra.rs
@@ -85,7 +85,6 @@ pub(crate) enum Trait {
     Default,
     PartialEq,
     /// User-provided path.
-    #[expect(dead_code, reason = "TODO: add user-specified derives")]
     User(String),
 }
 

--- a/back/src/writer.rs
+++ b/back/src/writer.rs
@@ -13,11 +13,12 @@ use naga::{
     valid::ModuleInfo,
 };
 
+use crate::Effect;
+use crate::config::{RuleInput, WriterFlags};
 use crate::conv::{self, BinOpClassified};
 use crate::ra::{self, PrintAst as _};
-use crate::util::Gensym;
+use crate::util::{Gensym, GlobalKind};
 use crate::{Config, Error};
-use crate::{config::WriterFlags, util::GlobalKind};
 
 // -------------------------------------------------------------------------------------------------
 
@@ -695,13 +696,20 @@ impl Writer {
         let name = &self.names[&NameKey::Type(struct_handle)];
         let self_ty = ra::Type::User(name.clone(), ra::Generics::None);
 
-        let derives: Cow<'static, [ra::Trait]> = Cow::Borrowed(&[
+        let mut derives: Cow<'static, [ra::Trait]> = Cow::Borrowed(&[
             ra::Trait::Clone,
             ra::Trait::Copy,
             ra::Trait::Debug,
             ra::Trait::PartialEq,
         ]);
-        // TODO: support adding user-chosen derives.
+        for effect in self.config.apply_rules(&RuleInput {
+            r#struct: Some(name),
+        }) {
+            #[expect(irrefutable_let_patterns, reason = "will be more")]
+            if let Effect::Derive(name) = effect {
+                derives.to_mut().push(ra::Trait::User(name.clone()));
+            }
+        }
         let struct_attributes = vec![ra::Attribute::Derive(derives), ra::Attribute::ReprC];
 
         let mut fields: Vec<ra::Field> = Vec::with_capacity(members.len());

--- a/back/tests/textual.rs
+++ b/back/tests/textual.rs
@@ -7,7 +7,7 @@ use core::fmt;
 
 use pretty_assertions::assert_eq;
 
-use naga_rust_back::Config;
+use naga_rust_back::{Condition, Config, Effect};
 
 // -------------------------------------------------------------------------------------------------
 
@@ -365,6 +365,44 @@ fn struct_decl_and_ctor() {
             }
             "
         }
+    );
+}
+
+#[test]
+fn struct_custom_derive_rule() {
+    assert_eq!(
+        translate(
+            Config::new().rule((
+                Condition::Struct("Foo".to_owned()),
+                Effect::Derive("bytemuck::NoUninit".to_owned())
+            )),
+            r"
+            struct Foo { x: i32 }
+            struct Bar { x: i32 }
+            "
+        ),
+        indoc::indoc! {"
+            #[::naga_rust_rt::derive(::naga_rust_rt::Clone, ::naga_rust_rt::Copy, ::naga_rust_rt::Debug, ::naga_rust_rt::PartialEq, bytemuck::NoUninit)]
+            #[repr(C)]
+            struct Foo {
+                x: i32,
+            }
+            impl Foo {
+                fn new(x: impl ::naga_rust_rt::Into<i32>) -> Self {
+                    Self { x: ::naga_rust_rt::into(x) }
+                }
+            }
+            #[::naga_rust_rt::derive(::naga_rust_rt::Clone, ::naga_rust_rt::Copy, ::naga_rust_rt::Debug, ::naga_rust_rt::PartialEq)]
+            #[repr(C)]
+            struct Bar {
+                x: i32,
+            }
+            impl Bar {
+                fn new(x: impl ::naga_rust_rt::Into<i32>) -> Self {
+                    Self { x: ::naga_rust_rt::into(x) }
+                }
+            }
+        "}
     );
 }
 

--- a/embed/src/configuration_syntax.md
+++ b/embed/src/configuration_syntax.md
@@ -1,3 +1,5 @@
+# Configuration
+
 The available configuration options are:
 
 * `allow_unimplemented = true | false` (default: `false`):
@@ -12,7 +14,9 @@ The available configuration options are:
 * `include_functions = true | false` (default: `true`):
 
   Whether the translated code includes functions.
-  When this is false, only `struct`s and `const`s are translated.
+
+  This may be disabled to produce an output containing only `struct`s and `const`s,
+  and remove any requirement to specify a `global_struct` or `resource_struct`.   
 
 * `public_items = true | false` (default: `false`):
 
@@ -34,3 +38,16 @@ The available configuration options are:
 
   Allow declarations of resources (uniforms), generate a struct with the given name to hold
   them, and make all functions methods of that struct if `global_struct` is not also set.
+
+* `rule(condition => effect)` or<br>
+  `rule(effect)`:
+
+  Defines rules that modify how specific parts of the shader are translated to Rust.
+
+  The available **conditions** are:
+
+  * `struct(StructNameHere)`: matches a single struct according to its name in the shader code.
+
+  The available **effects** are:
+
+  * `derive(DeriveMacroNameHere)`: Adds `#[derive(DeriveMacroNameHere)]` to the translated struct.

--- a/embed/src/lib.rs
+++ b/embed/src/lib.rs
@@ -50,7 +50,7 @@
 /// include_wgsl_mr!("src/example.wgsl");
 /// ```
 ///
-/// If any configuration is needed, write it attribute-style before the source code literal:
+/// If any configuration is needed, write it before the source code literal:
 ///
 /// ```
 /// # use naga_rust_embed::include_wgsl_mr;
@@ -80,7 +80,7 @@ pub use naga_rust_macros::include_wgsl_mr;
 /// }
 /// ```
 ///
-/// If any configuration is needed, write it attribute-style before the source code literal:
+/// If any configuration is needed, write it before the source code literal:
 ///
 /// ```
 /// # use naga_rust_embed::wgsl;

--- a/embed/tests/interop/main.rs
+++ b/embed/tests/interop/main.rs
@@ -7,6 +7,7 @@ mod globals_and_functions;
 mod math_functions;
 mod matrices;
 mod operators;
+mod rules;
 mod structs;
 mod textures;
 mod vector_construction;

--- a/embed/tests/interop/rules.rs
+++ b/embed/tests/interop/rules.rs
@@ -1,0 +1,24 @@
+use naga_rust_embed::wgsl;
+
+// -------------------------------------------------------------------------------------------------
+
+#[test]
+fn derive_rule() {
+    wgsl!(
+        rule(struct(DeriveYes) => derive(::core::cmp::PartialOrd)),
+        "
+        struct DeriveYes { x: i32, }
+        struct DeriveNo { x: i32, }
+        "
+    );
+
+    // If the rule applies to too many things, this will fail to compile.
+    impl PartialOrd for DeriveNo {
+        fn partial_cmp(&self, _other: &Self) -> Option<std::cmp::Ordering> {
+            unimplemented!()
+        }
+    }
+
+    // If the rule applies to too few things, this will fail to compile.
+    assert!(DeriveYes { x: 1 } < DeriveYes { x: 2 });
+}

--- a/macros/src/parse_config.rs
+++ b/macros/src/parse_config.rs
@@ -1,3 +1,7 @@
+use naga_rust_back::Condition;
+use naga_rust_back::Effect;
+use naga_rust_back::Rule;
+use proc_macro2::Spacing;
 use proc_macro2::Span;
 use proc_macro2::TokenStream;
 use proc_macro2::TokenTree;
@@ -52,6 +56,8 @@ impl ConfigAndStr {
                         }
                     }
 
+                    input.expect_eof("nothing")?;
+
                     return Ok(Self {
                         config,
                         string_span: literal_token.span(),
@@ -63,29 +69,31 @@ impl ConfigAndStr {
                 TokenTree::Ident(option_name_ident) => {
                     let option_name = option_name_ident.to_string();
 
-                    match input.next_expect("`=`")? {
-                        TokenTree::Punct(punct) if punct.as_char() == '=' => {}
-                        other => {
-                            return Err(MacroError::unexpected_token(&other, "`=`"));
-                        }
-                    }
-
                     config = match &*option_name {
                         // The options parsed by this match should also be documented in
                         // `embed/src/configuration_syntax.md`.
                         // The ordering here is alphabetical.
-                        "allow_unimplemented" => config.allow_unimplemented(input.expect_bool()?),
-                        "explicit_types" => config.explicit_types(input.expect_bool()?),
-                        "global_struct" => config.global_struct(input.expect_ident()?),
-                        "include_functions" => config.include_functions(input.expect_bool()?),
-                        "public_items" => config.public_items(input.expect_bool()?),
+                        "allow_unimplemented" => {
+                            config.allow_unimplemented(input.expect_eq()?.expect_bool()?)
+                        }
+                        "explicit_types" => {
+                            config.explicit_types(input.expect_eq()?.expect_bool()?)
+                        }
+                        "global_struct" => config.global_struct(input.expect_eq()?.expect_ident()?),
+                        "include_functions" => {
+                            config.include_functions(input.expect_eq()?.expect_bool()?)
+                        }
+                        "public_items" => config.public_items(input.expect_eq()?.expect_bool()?),
                         // TODO: raw_pointers doesn’t actually work, and will need to be marked unsafe
                         // when it is implemented. So, we don’t offer it yet.
                         //
                         // "raw_pointers" => {
                         //     config.raw_pointers(input.expect_bool()?)
                         // }
-                        "resource_struct" => config.resource_struct(input.expect_ident()?),
+                        "resource_struct" => {
+                            config.resource_struct(input.expect_eq()?.expect_ident()?)
+                        }
+                        "rule" => config.rule(parse_rule(&mut input)?),
                         _ => {
                             return Err(MacroError::new(
                                 option_name_ident.span(),
@@ -119,4 +127,146 @@ fn macro_default_config() -> Config {
         // Helps give better errors when the generated code is wrong.
         // TODO: Consider turning this back off for efficiency? Measure impact?
         .explicit_types(true)
+}
+
+// -------------------------------------------------------------------------------------------------
+
+fn parse_rule(input: &mut Parser) -> Result<Rule, MacroError> {
+    // The grammar of a rule is
+    //   (condition '=>')? effect*
+    // but for simplicity and error reporting, the implementation is more like
+    //   (condition | effect | '=>')*
+    // with separate validation of the ordering.
+
+    // A condition or an effect.
+    // TODO: Better name than "term"?
+    enum Term {
+        Condition(Condition),
+        Effect(Effect),
+    }
+
+    let mut input = input.expect_parenthesis()?;
+
+    let mut conditions = Vec::new();
+    let mut effects = Vec::new();
+    let mut seen_arrow = false;
+
+    'rule: loop {
+        match input.next() {
+            Some(TokenTree::Ident(term_ident)) => {
+                let term_ident_string = term_ident.to_string();
+                let mut term_args = input.expect_parenthesis()?;
+
+                let term_value = match &*term_ident_string {
+                    "derive" => Term::Effect(Effect::Derive(parse_path(
+                        &mut term_args,
+                        "a path to a derive macro",
+                    )?)),
+                    "struct" => Term::Condition(Condition::Struct(
+                        term_args.expect_ident_tok("a struct name")?.to_string(),
+                    )),
+                    _ => {
+                        return Err(MacroError::new(
+                            term_ident.span(),
+                            format!("`{term_ident}` is not the name of a rule condition or effect"),
+                        ));
+                    }
+                };
+
+                match term_value {
+                    Term::Condition(condition) => {
+                        if seen_arrow {
+                            return Err(MacroError::new(
+                                term_ident.span(),
+                                "rule conditions must come before the `=>`".to_string(),
+                            ));
+                        }
+                        conditions.push(condition);
+                    }
+                    Term::Effect(effect) => {
+                        if !conditions.is_empty() && !seen_arrow {
+                            return Err(MacroError::new(
+                                term_ident.span(),
+                                "rule effects must be separated from conditions by `=>`"
+                                    .to_string(),
+                            ));
+                        }
+                        effects.push(effect);
+                    }
+                }
+            }
+            Some(ref arrow_tok @ TokenTree::Punct(ref punct)) if punct.as_char() == '=' => {
+                input.expect_punct('>', "`=>`")?;
+                if seen_arrow {
+                    return Err(MacroError::new(
+                        arrow_tok.span(),
+                        "rule must have at most one `=>`".to_string(),
+                    ));
+                } else {
+                    seen_arrow = true;
+                }
+            }
+            None => {
+                if effects.is_empty() {
+                    return Err(MacroError::new(
+                        input.previous_token_span.unwrap(),
+                        "rule must have at least one effect".to_string(),
+                    ));
+                } else {
+                    break 'rule;
+                }
+            }
+            Some(other) => {
+                return Err(MacroError::unexpected_token(
+                    &other,
+                    "a rule condition or effect",
+                ));
+            }
+        }
+    }
+
+    Ok(Rule {
+        conditions,
+        effects,
+    })
+}
+
+fn parse_path(input: &mut Parser, description: &'static str) -> Result<String, MacroError> {
+    let mut path = String::new();
+
+    loop {
+        match input.next() {
+            Some(TokenTree::Ident(ident)) => {
+                path.push_str(&ident.to_string());
+            }
+            Some(TokenTree::Punct(punct))
+                if punct.as_char() == ':' && punct.spacing() == Spacing::Joint =>
+            {
+                // If we found one colon, there must be a second colon.
+                input.expect_punct(':', "a path separator `::`")?;
+                path.push_str("::");
+            }
+            Some(TokenTree::Punct(ref punct)) if punct.as_char() == '<' => {
+                return Err(MacroError::new(
+                    punct.span(),
+                    "paths with parameters are not yet supported".to_string(),
+                ));
+            }
+            None => {
+                break;
+            }
+            Some(other) => {
+                return Err(MacroError::unexpected_token(&other, description));
+            }
+        }
+    }
+
+    if path.is_empty() {
+        return Err(MacroError::new(
+            input.previous_token_span.unwrap_or_else(Span::call_site),
+            format!("expected {description}; found nothing"),
+        ));
+    }
+
+    Ok(path)
 }

--- a/macros/src/parsing.rs
+++ b/macros/src/parsing.rs
@@ -11,7 +11,7 @@ use proc_macro2::TokenTree;
 /// Wrapper around a token stream iterator which provides help with parsing.
 /// Performs a similar function to `syn::ParseStream`.
 pub(crate) struct Parser {
-    previous_token_span: Option<Span>,
+    pub previous_token_span: Option<Span>,
     iter: proc_macro2::token_stream::IntoIter,
 }
 
@@ -53,9 +53,17 @@ impl Parser {
     // wouldn’t make sense if we did.
 
     pub fn expect_ident(&mut self) -> Result<String, MacroError> {
-        match unwrap_invisible_groups(self.next_expect("identifier")?) {
+        match unwrap_invisible_groups(self.next_expect("an identifier")?) {
             TokenTree::Ident(ident) => Ok(ident.to_string()),
             other => Err(MacroError::unexpected_token(&other, "an identifier")),
+        }
+    }
+
+    /// Like `expect_ident` but returning the token and accepting a description
+    pub fn expect_ident_tok(&mut self, description: &'static str) -> Result<Ident, MacroError> {
+        match unwrap_invisible_groups(self.next_expect(description)?) {
+            TokenTree::Ident(ident) => Ok(ident),
+            other => Err(MacroError::unexpected_token(&other, description)),
         }
     }
 
@@ -64,6 +72,40 @@ impl Parser {
         match litrs::BoolLit::try_from(&token) {
             Ok(lit) => Ok(lit.value()),
             Err(_) => Err(MacroError::unexpected_token(&token, "a boolean literal")),
+        }
+    }
+
+    /// Consume a specific punctuation token token or error, then return `self` for chaining.
+    pub fn expect_punct(
+        &mut self,
+        ch: char,
+        description: &'static str,
+    ) -> Result<&mut Self, MacroError> {
+        match self.next_expect(description)? {
+            TokenTree::Punct(punct) if punct.as_char() == ch => Ok(self),
+            other => Err(MacroError::unexpected_token(&other, description)),
+        }
+    }
+
+    /// Consume a `=` token or error, then return `self` for chaining.
+    pub fn expect_eq(&mut self) -> Result<&mut Self, MacroError> {
+        self.expect_punct('=', "`=`")
+    }
+
+    pub fn expect_parenthesis(&mut self) -> Result<Parser, MacroError> {
+        match self.next_expect("parenthesis")? {
+            TokenTree::Group(group) if group.delimiter() == Delimiter::Parenthesis => Ok(Parser {
+                previous_token_span: Some(group.span_open()),
+                iter: group.stream().into_iter(),
+            }),
+            other => Err(MacroError::unexpected_token(&other, "parenthesis")),
+        }
+    }
+
+    pub(crate) fn expect_eof(&mut self, description: &'static str) -> Result<(), MacroError> {
+        match self.next() {
+            Some(other) => Err(MacroError::unexpected_token(&other, description)),
+            None => Ok(()),
         }
     }
 }

--- a/macros/src/tests.rs
+++ b/macros/src/tests.rs
@@ -98,3 +98,78 @@ fn non_comma_after_input() {
         "expected comma or nothing; found `+`"
     );
 }
+
+mod rule_errors {
+    use super::*;
+
+    #[test]
+    fn empty_rule() {
+        assert_eq!(
+            expect_error(quote! { rule(), "" }),
+            "rule must have at least one effect"
+        );
+    }
+
+    #[test]
+    fn condition_but_no_effect() {
+        assert_eq!(
+            expect_error(quote! { rule(struct(Foo)), "" }),
+            "rule must have at least one effect"
+        );
+    }
+
+    #[test]
+    fn empty_condition() {
+        assert_eq!(
+            expect_error(quote! { rule(struct()), "" }),
+            "expected a struct name; found nothing after this"
+        );
+    }
+
+    #[test]
+    fn unknown_name() {
+        assert_eq!(
+            expect_error(quote! { rule(somethingorother()), "" }),
+            "`somethingorother` is not the name of a rule condition or effect"
+        );
+    }
+    #[test]
+    fn no_arrow() {
+        assert_eq!(
+            expect_error(quote! { rule(struct(Foo) derive(PartialOrd)), "" }),
+            "rule effects must be separated from conditions by `=>`"
+        );
+    }
+
+    #[test]
+    fn extra_arrow() {
+        assert_eq!(
+            expect_error(quote! { rule(struct(Foo) => derive(PartialOrd) => derive(Ord)), "" }),
+            "rule must have at most one `=>`"
+        );
+    }
+
+    #[test]
+    fn empty_effect() {
+        assert_eq!(
+            expect_error(quote! { rule(struct(Foo) => derive()), "" }),
+            "expected a path to a derive macro; found nothing"
+        );
+    }
+
+    #[test]
+    fn other_token() {
+        assert_eq!(
+            expect_error(quote! { rule(struct(Foo) => :), "" }),
+            "expected a rule condition or effect; found `:`"
+        );
+    }
+
+    #[test]
+    fn path_colon_not_joint() {
+        assert_eq!(
+            expect_error(quote! { rule(derive(some : : trait)), "" }),
+            "expected a path to a derive macro; found `:`"
+        );
+    }
+}


### PR DESCRIPTION
Rules allow customizing the translation of specific items.

Currently, the only kind of rule adds `#[derive]` to a specific struct or all structs.