### PR TITLE
Replace dummy attributes for entry points with doc.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,7 +885,6 @@ version = "0.2.0"
 dependencies = [
  "bytemuck",
  "mutants",
- "naga-rust-macros",
  "num-traits",
  "paste",
  "static_assertions",

--- a/back/src/ra.rs
+++ b/back/src/ra.rs
@@ -368,11 +368,6 @@ pub(crate) enum Attribute {
 
     /// `repr(C)`
     ReprC,
-
-    /// Entry point function’s stage. Ignored.
-    Stage(naga::ShaderStage),
-    /// Compute entry point function’s workgroup size. Ignored.
-    WorkGroupSize([u32; 3]),
 }
 
 #[derive(Clone, Copy)]
@@ -970,27 +965,6 @@ impl PrintAst for Attribute {
             }
             Attribute::ReprC => {
                 out.write_str("repr(C)")?;
-            }
-            Attribute::Stage(shader_stage) => {
-                let stage_str = match shader_stage {
-                    naga::ShaderStage::Vertex => "vertex",
-                    naga::ShaderStage::Fragment => "fragment",
-                    naga::ShaderStage::Compute => "compute",
-                    naga::ShaderStage::Task => "task",
-                    naga::ShaderStage::Mesh => "mesh",
-                    naga::ShaderStage::RayGeneration => "ray_generation",
-                    naga::ShaderStage::Miss => "miss",
-                    naga::ShaderStage::AnyHit => "any_hit",
-                    naga::ShaderStage::ClosestHit => "closest_hit",
-                };
-                write!(out, "{runtime_path}::{stage_str}")?;
-            }
-            Attribute::WorkGroupSize(size) => {
-                write!(
-                    out,
-                    "{runtime_path}::workgroup_size({}, {}, {})",
-                    size[0], size[1], size[2]
-                )?;
             }
         }
         Ok(())

--- a/back/src/writer.rs
+++ b/back/src/writer.rs
@@ -456,20 +456,20 @@ impl Writer {
 
             // Translate all entry points
             for (index, ep) in module.entry_points.iter().enumerate() {
-                let entry_point_attributes = match ep.stage {
-                    ShaderStage::Vertex
-                    | ShaderStage::Fragment
-                    | ShaderStage::Task
-                    | ShaderStage::Mesh
-                    | ShaderStage::RayGeneration
-                    | ShaderStage::Miss
-                    | ShaderStage::AnyHit
-                    | ShaderStage::ClosestHit => vec![ra::Attribute::Stage(ep.stage)],
-                    ShaderStage::Compute => vec![
-                        ra::Attribute::Stage(ShaderStage::Compute),
-                        ra::Attribute::WorkGroupSize(ep.workgroup_size),
-                    ],
-                };
+                let entry_point_attributes = vec![ra::Attribute::Doc(format!(
+                    "Entry point for stage `{}`.",
+                    match ep.stage {
+                        ShaderStage::Vertex => "vertex",
+                        ShaderStage::Fragment => "fragment",
+                        ShaderStage::Compute => "compute",
+                        ShaderStage::Task => "task",
+                        ShaderStage::Mesh => "mesh",
+                        ShaderStage::RayGeneration => "ray_generation",
+                        ShaderStage::Miss => "miss",
+                        ShaderStage::AnyHit => "any_hit",
+                        ShaderStage::ClosestHit => "closest_hit",
+                    },
+                ))];
 
                 let func_ctx = back::FunctionCtx {
                     ty: back::FunctionType::EntryPoint(index.try_into().unwrap()),

--- a/back/tests/textual.rs
+++ b/back/tests/textual.rs
@@ -90,8 +90,8 @@ fn entry_point() {
             }"
         ),
         indoc::indoc! {
-            r"
-            #[::naga_rust_rt::fragment]
+            r#"
+            #[doc = "Entry point for stage `fragment`."]
             fn main(position: impl ::naga_rust_rt::Into<::naga_rust_rt::Vec4<f32>>) -> ::naga_rust_rt::Vec4<f32> {
                 ::naga_rust_rt::into(v_main(::naga_rust_rt::into(position)))
             }
@@ -99,7 +99,7 @@ fn entry_point() {
             fn v_main(position: ::naga_rust_rt::Vec4<f32>) -> ::naga_rust_rt::Vec4<f32> {
                 return ::naga_rust_rt::Vec4::splat_from_scalar(::naga_rust_rt::Scalar(1f32));
             }
-            "
+            "#
         }
     );
 }

--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -37,7 +37,6 @@ bytemuck = ["dep:bytemuck"]
 bytemuck = { workspace = true, optional = true }
 mutants.workspace = true
 num-traits = { workspace = true, default-features = false, features = ["libm"] }
-naga-rust-macros.workspace = true
 paste.workspace = true
 
 [dev-dependencies]

--- a/rt/src/lib.rs
+++ b/rt/src/lib.rs
@@ -59,12 +59,6 @@ where
 
 pub fn discard() {
     // Best we can do for now, until we implement a codegen option to return Result instead.
+    // TODO: This should be (when possible) `panic_any` with a recognizable payload.
     panic!("shader reached discard instruction");
 }
-
-// Attributes which naga_rust_back emits that are currently for documentation purposes only,
-// and don’t actually transform the item.
-pub use naga_rust_macros::dummy_attribute as compute;
-pub use naga_rust_macros::dummy_attribute as fragment;
-pub use naga_rust_macros::dummy_attribute as vertex;
-pub use naga_rust_macros::dummy_attribute as workgroup_size;


### PR DESCRIPTION
This allows removing the dependency from `naga-rust-rt` on `naga-rust-macros`, improving build performance.