### PR TITLE
Handle unsigned texture coordinates.

### DIFF
--- a/back/CHANGELOG.md
+++ b/back/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## Unreleased
 
+## Added
+
 ## Fixed
 
+* `textureLoad()` with `u32` coordinates now succeeds instead of generating a type error.
 * The visibility of the `global_struct` and `resource_struct` is now controlled by `Config::public_items()` instead of always being private.
 
 ## 0.3.0 (2026-07-27)

--- a/back/CHANGELOG.md
+++ b/back/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for `naga-rust-back`
 
+## Unreleased
+
+## Fixed
+
+* The visibility of the `global_struct` and `resource_struct` is now controlled by `Config::public_items()` instead of always being private.
+
 ## 0.3.0 (2026-07-27)
 
 This release focuses on expanding to a new use case: sharing declarations between Rust and shaders, without actually executing shader functions as Rust.

--- a/back/src/writer.rs
+++ b/back/src/writer.rs
@@ -1372,7 +1372,35 @@ impl Writer {
                 ra::RtItem::TextureLoad,
                 [
                     self.expr_ast_with_indirection(image, expr_ctx, Indirection::Ref)?,
-                    self.translate_expr(coordinate, expr_ctx)?,
+                    // Kludge: `Expression::ImageLoad` documentation claims that `coordinate` always
+                    // has `Sint` component type, but the WGSL frontend may produce `Uint` and
+                    // validation does not reject this.
+                    //
+                    // TODO: File issue against Naga and get this inconsistency resolved.
+                    //
+                    // TODO: When we next make a breaking `naga-rust-rt` release, move this coercion
+                    // into its interface for texture loads?
+                    {
+                        let coordinate_expr_without_conversion =
+                            self.translate_expr(coordinate, expr_ctx)?;
+                        match expr_ctx.resolve_type(coordinate) {
+                            TypeInner::Scalar(naga::Scalar::U32)
+                            | TypeInner::Vector {
+                                size: _,
+                                scalar: naga::Scalar::U32,
+                            } => ra::Expr::Method(
+                                Box::new(coordinate_expr_without_conversion),
+                                Cow::Borrowed("cast_elem_as_i32"),
+                                vec![],
+                            ),
+                            TypeInner::Scalar(naga::Scalar::I32)
+                            | TypeInner::Vector {
+                                size: _,
+                                scalar: naga::Scalar::I32,
+                            } => coordinate_expr_without_conversion,
+                            ty => panic!("unhandled texture coordinate type {ty:?}"),
+                        }
+                    },
                     if let Some(array_index) = array_index {
                         ra::Expr::call_rt(
                             ra::RtItem::ScalarIntoInner,

--- a/embed/src/configuration_syntax.md
+++ b/embed/src/configuration_syntax.md
@@ -20,9 +20,12 @@ The available configuration options are:
 
 * `public_items = true | false` (default: `false`):
 
-  Whether translated items have `pub` visibility instead of private.
+  Whether generated items have `pub` visibility instead of private.
   
-  This option applies to all functions or methods, and all fields of translated structs.
+  This option applies to all functions, methods, constants, and structs, and
+  all fields of generated structs.
+  It affects both structs translated from the shader code, and the
+  `global_struct` and `resource_struct` if present.
 
 * `global_struct = StructNameHere`:
 

--- a/embed/tests/interop/textures.rs
+++ b/embed/tests/interop/textures.rs
@@ -44,6 +44,10 @@ where
 
 // -------------------------------------------------------------------------------------------------
 
+// The `loadi` and `loadu` functions are due to the fact that, despite what [`naga::Expression`]
+// documentation currently says, `Expression::ImageLoad` appears with both `i32`s and `u32`s.
+// Therefore, Naga is not canonicalizing them for us and we must handle both in each case.
+
 #[test]
 fn query_and_load_1d() {
     wgsl!(
@@ -53,9 +57,13 @@ fn query_and_load_1d() {
         fn dimensions_and_mip_levels() -> vec2u {
             return vec2(textureDimensions(my_texture, 0), textureNumLevels(my_texture));
         }
-        fn load(position: i32) -> vec4f {
+        fn loadi(position: i32) -> vec4f {
             return textureLoad(my_texture, position, 0);
-        }"
+        }
+        fn loadu(position: u32) -> vec4f {
+            return textureLoad(my_texture, position, 0);
+        }
+        "
     );
 
     let mut call_count = 0;
@@ -75,8 +83,9 @@ fn query_and_load_1d() {
         },
     };
     assert_eq!(res.dimensions_and_mip_levels(), Vec2::new(100, 1));
-    assert_eq!(res.load(Scalar::new(10)), Vec4::new(1.0, 2.0, 3.0, 4.0));
-    assert_eq!(call_count, 1);
+    assert_eq!(res.loadi(Scalar::new(10i32)), Vec4::new(1.0, 2.0, 3.0, 4.0));
+    assert_eq!(res.loadu(Scalar::new(10u32)), Vec4::new(1.0, 2.0, 3.0, 4.0));
+    assert_eq!(call_count, 2);
 }
 
 #[test]
@@ -88,9 +97,13 @@ fn query_and_load_2d() {
         fn dimensions_and_mip_levels() -> vec3u {
             return vec3(textureDimensions(my_texture, 0), textureNumLevels(my_texture));
         }
-        fn load(position: vec2i) -> vec4f {
+        fn loadi(position: vec2i) -> vec4f {
             return textureLoad(my_texture, position, 0);
-        }"
+        }
+        fn loadu(position: vec2u) -> vec4f {
+            return textureLoad(my_texture, position, 0);
+        }
+        "
     );
 
     let mut call_count = 0;
@@ -110,8 +123,15 @@ fn query_and_load_2d() {
         },
     };
     assert_eq!(res.dimensions_and_mip_levels(), Vec3::new(100u32, 100, 1));
-    assert_eq!(res.load(Vec2::new(10, 20)), Vec4::new(1.0, 2.0, 3.0, 4.0));
-    assert_eq!(call_count, 1);
+    assert_eq!(
+        res.loadi(Vec2::new(10i32, 20)),
+        Vec4::new(1.0, 2.0, 3.0, 4.0)
+    );
+    assert_eq!(
+        res.loadu(Vec2::new(10u32, 20)),
+        Vec4::new(1.0, 2.0, 3.0, 4.0)
+    );
+    assert_eq!(call_count, 2);
 }
 
 #[test]
@@ -123,9 +143,13 @@ fn query_and_load_2d_array() {
         fn dimensions_and_layers() -> vec3u {
             return vec3(textureDimensions(my_texture, 0), textureNumLayers(my_texture));
         }
-        fn load(position: vec2i) -> vec4f {
+        fn loadi(position: vec2i) -> vec4f {
             return textureLoad(my_texture, position, 3, 0);
-        }"
+        }
+        fn loadu(position: vec2u) -> vec4f {
+            return textureLoad(my_texture, position, 3, 0);
+        }
+        "
     );
 
     let mut call_count = 0;
@@ -147,8 +171,15 @@ fn query_and_load_2d_array() {
         },
     };
     assert_eq!(res.dimensions_and_layers(), Vec3::new(100u32, 100, 7));
-    assert_eq!(res.load(Vec2::new(10, 20)), Vec4::new(1.0, 2.0, 3.0, 4.0));
-    assert_eq!(call_count, 1);
+    assert_eq!(
+        res.loadi(Vec2::new(10i32, 20)),
+        Vec4::new(1.0, 2.0, 3.0, 4.0)
+    );
+    assert_eq!(
+        res.loadu(Vec2::new(10u32, 20)),
+        Vec4::new(1.0, 2.0, 3.0, 4.0)
+    );
+    assert_eq!(call_count, 2);
 }
 
 #[test]
@@ -160,9 +191,13 @@ fn query_and_load_2d_multisampled() {
         fn dimensions_and_layers() -> vec3u {
             return vec3(textureDimensions(my_texture), textureNumSamples(my_texture));
         }
-        fn load(position: vec2i) -> vec4f {
+        fn loadi(position: vec2i) -> vec4f {
             return textureLoad(my_texture, position, 3);
-        }"
+        }
+        fn loadu(position: vec2u) -> vec4f {
+            return textureLoad(my_texture, position, 3);
+        }
+        "
     );
 
     let mut call_count = 0;
@@ -184,8 +219,15 @@ fn query_and_load_2d_multisampled() {
         },
     };
     assert_eq!(res.dimensions_and_layers(), Vec3::new(100u32, 100, 7));
-    assert_eq!(res.load(Vec2::new(10, 20)), Vec4::new(1.0, 2.0, 3.0, 4.0));
-    assert_eq!(call_count, 1);
+    assert_eq!(
+        res.loadi(Vec2::new(10i32, 20)),
+        Vec4::new(1.0, 2.0, 3.0, 4.0)
+    );
+    assert_eq!(
+        res.loadu(Vec2::new(10u32, 20)),
+        Vec4::new(1.0, 2.0, 3.0, 4.0)
+    );
+    assert_eq!(call_count, 2);
 }
 
 #[test]
@@ -197,9 +239,13 @@ fn query_and_load_3d() {
         fn dimensions_and_mip_levels() -> vec4u {
             return vec4(textureDimensions(my_texture, 0), textureNumLevels(my_texture));
         }
-        fn load(position: vec3i) -> vec4f {
+        fn loadi(position: vec3i) -> vec4f {
             return textureLoad(my_texture, position, 0);
-        }"
+        }
+        fn loadu(position: vec3u) -> vec4f {
+            return textureLoad(my_texture, position, 0);
+        }
+        "
     );
 
     let mut call_count = 0;
@@ -223,10 +269,14 @@ fn query_and_load_3d() {
         Vec4::new(100u32, 100, 100, 1)
     );
     assert_eq!(
-        res.load(Vec3::new(10, 20, 30)),
+        res.loadi(Vec3::new(10i32, 20, 30)),
         Vec4::new(1.0, 2.0, 3.0, 4.0)
     );
-    assert_eq!(call_count, 1);
+    assert_eq!(
+        res.loadu(Vec3::new(10u32, 20, 30)),
+        Vec4::new(1.0, 2.0, 3.0, 4.0)
+    );
+    assert_eq!(call_count, 2);
 }
 
 // TODO: test cube and cube_array types.


### PR DESCRIPTION
Note that this change is a workaround designed to apply to a compatible release. When we have a chance to make a breaking change, we should handle the type adjustment in `naga-rust-rt` instead.