### PR TITLE
Fix 3-vector overload of `mix()`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "naga-rust-back"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arrayvec",
  "bitflags 2.13.1",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "naga-rust-embed"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "exhaust",
  "indoc",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "naga-rust-rt"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytemuck",
  "mutants",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ repository = "https://github.com/kpreid/naga-rust/"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-naga-rust-back = { version = "0.3.0", path = "back" }
-naga-rust-embed = { version = "0.3.0", path = "embed" }
+naga-rust-back = { version = "0.4.0", path = "back" }
+naga-rust-embed = { version = "0.3.1", path = "embed" }
 naga-rust-macros = { version = "0.3.0", path = "macros" }
-naga-rust-rt = { version = "0.3.0", path = "rt" }
+naga-rust-rt = { version = "0.4.0", path = "rt" }
 
 arrayvec = { version = "0.7.6", default-features = false }
 bitflags = "2.9"

--- a/back/CHANGELOG.md
+++ b/back/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## Unreleased
 
-## Added
-
 ## Fixed
 
+* `mix()` with 3 vector arguments no longer fails to compile.
 * `textureLoad()` with `u32` coordinates now succeeds instead of generating a type error.
 * The visibility of the `global_struct` and `resource_struct` is now controlled by `Config::public_items()` instead of always being private.
 

--- a/back/CHANGELOG.md
+++ b/back/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for `naga-rust-back`
 
-## Unreleased
+## 0.4.0 (Unreleased)
 
 ## Fixed
 

--- a/back/Cargo.toml
+++ b/back/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "naga-rust-back"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version.workspace = true
 description = "Backend for the Naga shader translator which generates Rust code."

--- a/back/src/conv.rs
+++ b/back/src/conv.rs
@@ -1,6 +1,4 @@
-/*!
-Conversion of Naga/shader vocabulary to Rust.
-*/
+//! Conversion of Naga/shader vocabulary to Rust.
 
 use alloc::boxed::Box;
 
@@ -77,9 +75,11 @@ pub(crate) fn keywords_2024() -> &'static KeywordSet {
 
 /// Converts a [`MathFunction`] to a Rust method name.
 ///
-/// These methods are implemented on `naga_rust_rt` vector types, and also overlap
-/// with Rust `std` functions on scalars.
-pub(crate) fn math_function_to_method(f: naga::MathFunction) -> &'static str {
+/// These methods are implemented on `naga_rust_rt` `Vec*` and `Scalar` types.
+pub(crate) fn math_function_to_method(
+    f: naga::MathFunction,
+    arg_types: &[&naga::TypeInner],
+) -> &'static str {
     use naga::MathFunction as Mf;
     match f {
         Mf::Abs => "abs",
@@ -127,7 +127,13 @@ pub(crate) fn math_function_to_method(f: naga::MathFunction) -> &'static str {
         Mf::Refract => "refract",
         Mf::Sign => "sign",
         Mf::Fma => "mul_add",
-        Mf::Mix => "mix",
+        Mf::Mix => match arg_types[2].components() {
+            None => "mix_scalar",
+            Some(2..) => "mix_vector",
+            Some(0 | 1) => unreachable!(
+                "third argument to mix() must be scalar or vector, but got {arg_types:?}"
+            ),
+        },
         Mf::Step => "step",
         Mf::SmoothStep => "smoothstep",
         Mf::Sqrt => "sqrt",

--- a/back/src/writer.rs
+++ b/back/src/writer.rs
@@ -4,8 +4,9 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
-use arrayvec::ArrayVec;
 use core::fmt::Write;
+
+use arrayvec::ArrayVec;
 
 use naga::{
     Expression, Handle, Module, ShaderStage, TypeInner, back,
@@ -1497,14 +1498,25 @@ impl Writer {
                 arg1,
                 arg2,
                 arg3,
-            } => ra::Expr::Method(
-                Box::new(self.translate_expr(first_arg, expr_ctx)?),
-                Cow::Borrowed(conv::math_function_to_method(fun)),
-                self.translate_exprs(
-                    expr_ctx,
-                    [arg1, arg2, arg3].into_iter().flatten(), // flatten options into nonexistence
-                )?,
-            ),
+            } => {
+                // Collect the types of the arguments, so that we can resolve overloads that can’t
+                // be resolved just by the first argument being used as a method receiver.
+                let types: ArrayVec<&TypeInner, 4> = ArrayVec::from_iter(
+                    [Some(first_arg), arg1, arg2, arg3]
+                        .into_iter()
+                        .flatten()
+                        .map(|arg| expr_ctx.resolve_type(arg)),
+                );
+
+                ra::Expr::Method(
+                    Box::new(self.translate_expr(first_arg, expr_ctx)?),
+                    Cow::Borrowed(conv::math_function_to_method(fun, &types)),
+                    self.translate_exprs(
+                        expr_ctx,
+                        [arg1, arg2, arg3].into_iter().flatten(), // flatten options into nonexistence
+                    )?,
+                )
+            }
 
             Expression::Swizzle {
                 size,

--- a/embed/CHANGELOG.md
+++ b/embed/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for `naga-rust-embed`
 
-## Unreleased
+## 0.3.1 (Unreleased)
 
 ## Fixed
 

--- a/embed/CHANGELOG.md
+++ b/embed/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog for `naga-rust-embed`
 
+## Unreleased
+
+## Fixed
+
+* `mix()` with 3 vector arguments no longer fails to compile.
+* `textureLoad()` with `u32` coordinates now succeeds instead of generating a type error.
+* The visibility of the `global_struct` and `resource_struct` is now controlled by the `public_items` configuration instead of always being private.
+
 ## 0.3.0 (2026-07-27)
 
 This release focuses on expanding to a new use case: sharing declarations between Rust and shaders, without actually executing shader functions as Rust.

--- a/embed/Cargo.toml
+++ b/embed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "naga-rust-embed"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version.workspace = true
 description = "Translates WGSL shader code to Rust embedded in your Rust code."

--- a/embed/tests/interop/math_functions.rs
+++ b/embed/tests/interop/math_functions.rs
@@ -146,7 +146,60 @@ math_function_test!(
     [((1, 2), 1), ((2, 1), 1), ((1, 1), 1)]
 );
 
-// TODO: mix
+math_function_test!(
+    mix_scalar_scalar,
+    "fn shim(x: f32, y: f32, a: f32) -> f32 { return mix(x, y, a); }",
+    [
+        ((10.0, 20.0, 0.0), 10.0),
+        ((10.0, 20.0, 0.5), 15.0),
+        ((10.0, 20.0, 1.0), 20.0),
+    ]
+);
+
+math_function_test!(
+    mix_vector_scalar,
+    "fn shim(x: vec3f, y: vec3f, a: f32) -> vec3f { return mix(x, y, a); }",
+    [
+        (
+            (
+                Vec3::new(10.0, 10.0, 10.0),
+                Vec3::new(20.0, 30.0, 40.0),
+                0.0
+            ),
+            Vec3::new(10.0, 10.0, 10.0)
+        ),
+        (
+            (
+                Vec3::new(10.0, 10.0, 10.0),
+                Vec3::new(20.0, 30.0, 40.0),
+                0.5
+            ),
+            Vec3::new(15.0, 20.0, 25.0)
+        ),
+        (
+            (
+                Vec3::new(10.0, 10.0, 10.0),
+                Vec3::new(20.0, 30.0, 40.0),
+                1.0
+            ),
+            Vec3::new(20.0, 30.0, 40.0)
+        ),
+    ]
+);
+
+math_function_test!(
+    mix_vector_vector,
+    "fn shim(x: vec3f, y: vec3f, a: vec3f) -> vec3f { return mix(x, y, a); }",
+    [(
+        (
+            Vec3::new(10.0, 10.0, 10.0),
+            Vec3::new(20.0, 30.0, 40.0),
+            Vec3::new(0.0, 0.5, 1.0)
+        ),
+        Vec3::new(10.0, 20.0, 40.0)
+    ),]
+);
+
 // TODO: modf
 // TODO: normalize
 // TODO: MathFunction::Outer (not documented, not WGSL)

--- a/rt/CHANGELOG.md
+++ b/rt/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for `naga-rust-rt`
 
+## Unreleased
+
+### Changed
+
+* `Vec*::mix()` has been replaced by two methods, `mix_vector()` and `mix_scalar()`.
+
 ## 0.3.0 (2026-07-27)
 
 ### Added

--- a/rt/CHANGELOG.md
+++ b/rt/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for `naga-rust-rt`
 
-## Unreleased
+## 0.4.0 (Unreleased)
 
 ### Changed
 

--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "naga-rust-rt"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version.workspace = true
 description = "Support library for shaders compiled to Rust via the `naga-rust-back` library."

--- a/rt/src/vector.rs
+++ b/rt/src/vector.rs
@@ -324,10 +324,22 @@ macro_rules! impl_vector_float_arithmetic {
             pub fn length(self) -> Scalar<$float> {
                 Scalar(self.dot(self).0.sqrt())
             }
-            /// As per WGSL [`mix()`](https://www.w3.org/TR/2025/CRD-WGSL-20250322/#mix-builtin).
+            /// As per WGSL [`mix()`](https://www.w3.org/TR/2026/CRD-WGSL-20260716/#mix-builtin),
+            /// when the third argument is a scalar.
             #[inline]
-            pub const fn mix(self, rhs: Self, blend: Scalar<$float>) -> Self {
+            pub const fn mix_scalar(self, rhs: Self, blend: Scalar<$float>) -> Self {
                 $vec { $( $component: self.$component * (1.0 - blend.0) + rhs.$component * blend.0 ),*  }
+            }
+            /// As per WGSL [`mix()`](https://www.w3.org/TR/2026/CRD-WGSL-20260716/#mix-builtin),
+            /// when the third argument is a vector of the same number of components.
+            #[inline]
+            pub const fn mix_vector(self, rhs: Self, blend: Self) -> Self {
+                $vec {
+                    $(
+                        $component: self.$component * (1.0 - blend.$component)
+                            + rhs.$component * blend.$component
+                    ),*
+                }
             }
             /// As per WGSL [`fma()`](https://www.w3.org/TR/2025/CRD-WGSL-20250322/#fma-builtin).
             #[inline]


### PR DESCRIPTION
We could instead handle this overload using a trait, but we’d need to define a new trait, and it would disqualify the function from being a `const fn`.