### PR TITLE
Prepare release v0.4.0 (`embed` v0.3.1).

### DIFF
--- a/back/CHANGELOG.md
+++ b/back/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for `naga-rust-back`
 
-## 0.4.0 (Unreleased)
+## 0.4.0 (2026-07-31)
 
 ## Fixed
 

--- a/embed/CHANGELOG.md
+++ b/embed/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for `naga-rust-embed`
 
-## 0.3.1 (Unreleased)
+## 0.3.1 (2026-07-31)
 
 ## Fixed
 

--- a/rt/CHANGELOG.md
+++ b/rt/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for `naga-rust-rt`
 
-## 0.4.0 (Unreleased)
+## 0.4.0 (2026-07-31)
 
 ### Changed
 


### PR DESCRIPTION
Rather soon, but this release is needed in order to make my intended use in `all-is-cubes` possible by fixing visibility and compilation errors.