### PR TITLE
Also bump naga-rust-macros to v0.4.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "naga-rust-macros"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "litrs",
  "naga",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ license = "MIT OR Apache-2.0"
 [workspace.dependencies]
 naga-rust-back = { version = "0.4.0", path = "back" }
 naga-rust-embed = { version = "0.3.1", path = "embed" }
-naga-rust-macros = { version = "0.3.0", path = "macros" }
+naga-rust-macros = { version = "0.4.0", path = "macros" }
 naga-rust-rt = { version = "0.4.0", path = "rt" }
 
 arrayvec = { version = "0.7.6", default-features = false }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "naga-rust-macros"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version.workspace = true
 description = "Macros for the `naga-rust-embed` library."


### PR DESCRIPTION
Whoops. We have to do this too or the release won’t work as intended.